### PR TITLE
fix: point to correct lib files in packages

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -10,7 +10,8 @@
     "Kristján Oddsson <koddsson@gmail.com>"
   ],
   "type": "module",
-  "main": "src/index.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
   "files": [
     "dist"
   ],

--- a/decorators/package.json
+++ b/decorators/package.json
@@ -10,7 +10,8 @@
     "Kristján Oddsson <koddsson@gmail.com>"
   ],
   "type": "module",
-  "main": "src/index.ts",
+  "main": "lib/index.js",
+  "module": "lib/index.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
The packages were pointing to `.ts` version of themselves, but need to be `.js`.