### PR TITLE
fix(decorators): bind needs to pass this as argument

### DIFF
--- a/decorators/src/bind.ts
+++ b/decorators/src/bind.ts
@@ -7,7 +7,7 @@ const wrap = (obj: any, name: string, fn: (...args: any[]) => any) => {
     const oldFn = obj[name]
     obj[name] = function () {
       oldFn.call(this)
-      fn.call(this)
+      fn.call(this, this)
     }
   }
 }


### PR DESCRIPTION
`bind` requires `this` but wasn't called with it. This fixes that.