### PR TITLE
fix(decorators): correctly order register/bind calls

### DIFF
--- a/decorators/src/controller.ts
+++ b/decorators/src/controller.ts
@@ -6,6 +6,6 @@ interface CustomElement {
 }
 
 export function controller(classObject: CustomElement) {
-  register(classObject)
   bindEvents(classObject)
+  register(classObject)
 }


### PR DESCRIPTION
If `register()` is called first there's a possibility that the class gets instantiated before `bindEvents()` correctly decorates the code, resulting in a class that never calls `bind()`