### PR TITLE
fix(controller): apply function to prototype if it doesn't exist

### DIFF
--- a/catalyst/src/wrap.ts
+++ b/catalyst/src/wrap.ts
@@ -6,7 +6,7 @@
  */
 export function wrap(obj: any, name: string, fn: (...args: any[]) => any) {
   if (!obj.prototype[name]) {
-    obj[name] = fn
+    obj.prototype[name] = fn
   } else {
     const oldFn = obj.prototype[name]
     obj.prototype[name] = function () {


### PR DESCRIPTION
This fixes a bug that relates to #14, where the object given was supposed to wrap the prototype, not the object itself. #14 missed this line which should assign to the prototype but does not.