### PR TITLE
fix(bind): call controller method for any event target

### DIFF
--- a/catalyst/src/bind.ts
+++ b/catalyst/src/bind.ts
@@ -18,7 +18,7 @@ export function bind(controller: HTMLElement) {
         const methodDescriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(controller), method)
         if (methodDescriptor && typeof methodDescriptor.value == 'function') {
           el.addEventListener(eventName, (event: Event) => {
-            if (event.target === el) (controller as any)[method](event)
+            (controller as any)[method](event)
           })
         }
 


### PR DESCRIPTION
This fixes an issue where click handlers with nested children weren't being dispatched as the child would be set to `event.target`, and the event will not bubble.