### PR TITLE
docs: auto build reference

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -29,7 +29,7 @@ jobs:
       run: npm run build:docs:reference
     - run: |
         git config --local user.email "actions@github.com"
-        git config --local user.name "${{ github.actor }}"
+        git config --local user.name "Actions Auto Build"
         git add docs/_data/reference.json
         git commit -m "docs: compile reference.json"
         git push


### PR DESCRIPTION
This should automatically build the `docs/_data/reference.json` file, and commit it each time it changes.

Not sure if this will work - the only way to find out is to add it to master and see.