### PR TITLE
build: dont fail docs build if theres nothing to commit

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -31,5 +31,5 @@ jobs:
         git config --local user.email "actions@github.com"
         git config --local user.name "Actions Auto Build"
         git add docs/_data/reference.json
-        git commit -m "docs: compile reference.json"
+        git commit -m "docs: compile reference.json" || true
         git push


### PR DESCRIPTION
Currently the docs build fails if there is nothing to commit.

This changes that so that the commit command will never fail the build.