### PR TITLE
build: avoid building docs for main build

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "clean": "tsc --build --clean",
-    "build": "tsc --build && npm run build:docs:reference",
+    "build": "tsc --build",
     "build:docs": "npm run build:docs:reference && npm run build:docs:jekyll",
     "build:docs:jekyll": "cd docs && bundle exec jekyll build",
     "build:docs:reference": "typedoc --json docs/_data/reference.json",


### PR DESCRIPTION
This is not needed for the main build, only for docs. It is also automated as part of CI so not needed to be manually invoked