### PR TITLE
build: give nicer name to docs build task

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -27,7 +27,8 @@ jobs:
       run: npm i
     - name: Build Docs
       run: npm run build:docs:reference
-    - run: |
+    - name: Commit & Push Docs Data
+      run: |
         git config --local user.email "actions@github.com"
         git config --local user.name "Actions Auto Build"
         git add docs/_data/reference.json


### PR DESCRIPTION
Small thing that was bugging me, this makes the actions run for docs a little more legible.