### PR TITLE
Extend HTMLElement rather than controller in docs

### DIFF
--- a/docs/_guide/actions.md
+++ b/docs/_guide/actions.md
@@ -51,7 +51,7 @@ Remember! Actions are _automatically_ bound using the `@controller` decorator. T
 import { controller, target } from "@github/catalyst"
 
 @controller
-class HelloController extends Controller {
+class HelloController extends HTMLElement {
   @target nameTarget: HTMLElement
   @target outputTarget: HTMLElement
 


### PR DESCRIPTION
It should be either this or we should import `Controller` but I think this is correct.