### PR TITLE
feat: properly dasherize class names with acronyms

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -12,7 +12,7 @@ interface CustomElement {
 export function register(classObject: CustomElement): void {
   const name = classObject.name
     .replace(/([A-Z]($|[a-z]))/g, '-$1')
-    .replace(/(^-|-Element$)/, '')
+    .replace(/(^-|-Element$)/g, '')
     .toLowerCase()
   if (!window.customElements.get(name)) {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/test/register.js
+++ b/test/register.js
@@ -41,8 +41,8 @@ describe('register', () => {
   })
 
   it('automatically drops the `Element` suffix', () => {
-    class ASuffixedElement {}
-    register(ASuffixedElement)
-    expect(window.customElements.get('a-suffixed')).to.equal(ASuffixedElement)
+    class AutoCompleteElement {}
+    register(AutoCompleteElement)
+    expect(window.customElements.get('auto-complete')).to.equal(AutoCompleteElement)
   })
 })


### PR DESCRIPTION
This PR changes the dasherizing code such that it will now respect acronyms (that is, contiguous sets of capital letters) as single words, so for example:

 - `CSSStyle` -> `css-style` (old: `c-s-s-style`)
 - `XMLHttpRequest` -> `xml-http-request` (old: `x-m-l-http-request`)
 - `GEmoji` -> `g-emoji` (old: `g-emoji`, this is still a respected pattern)
 - `ClipX` -> `clip-x` (old: `clip-x`, this is still a respected pattern)

While this would technically be a breaking change, we're still Pre 1.0 so this is acceptable to release as a feature, IMO.