### PR TITLE
fix(listenForBind): allow any `Node` to be given as first param

### DIFF
--- a/src/bind.ts
+++ b/src/bind.ts
@@ -70,7 +70,7 @@ interface Subscription {
  * This returns a Subscription object which you can call `unsubscribe()` on to
  * stop further live updates.
  */
-export function listenForBind(el = document, batchSize = 30): Subscription {
+export function listenForBind(el: Node = document, batchSize = 30): Subscription {
   let closed = false
 
   const observer = new MutationObserver(mutations => {


### PR DESCRIPTION
This fixes a bug in `listenForBind`. The type of `el` was inferred, so it becomes `Document | undefined` which is not what we want. The type should be `Node` to allow us to register other, non `document` nodes, should we need to.

This is _just_ the `Node` type bug which comes from https://github.com/github/catalyst/pull/50, so we can get this one merged and squared away while we deal with the other bug of children not getting bound.