### PR TITLE
Provide a way to extend built-in element

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -6,16 +6,34 @@ interface CustomElement {
   new (): HTMLElement
 }
 
+function connect(classObject: CustomElement, tag?: string) {
+  wrap(classObject.prototype, 'connectedCallback', function (this: HTMLElement) {
+    this.toggleAttribute('data-catalyst', true)
+    bind(this)
+  })
+
+  if (tag) {
+    register(classObject, tag)
+  } else {
+    register(classObject)
+  }
+}
+
 /**
  * Controller is a decorator to be used over a class that extends HTMLElement.
  * It will automatically `register()` the component in the customElement
  * registry, as well as ensuring `bind(this)` is called on `connectedCallback`,
  * wrapping the classes `connectedCallback` method if needed.
  */
-export function controller(classObject: CustomElement): void {
-  wrap(classObject.prototype, 'connectedCallback', function (this: HTMLElement) {
-    this.toggleAttribute('data-catalyst', true)
-    bind(this)
-  })
-  register(classObject)
+export function controller(target: CustomElement): void
+export function controller(tag: string): (classObject: CustomElement) => void
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function controller(classObjectOrString: CustomElement | string) {
+  if (typeof classObjectOrString === 'string') {
+    return function (classObject: CustomElement): void {
+      connect(classObject, classObjectOrString)
+    }
+  } else {
+    connect(classObjectOrString)
+  }
 }

--- a/src/register.ts
+++ b/src/register.ts
@@ -9,7 +9,7 @@ interface CustomElement {
  *
  * Example: HelloController => hello-controller
  */
-export function register(classObject: CustomElement): void {
+export function register(classObject: CustomElement, extendsElement?: string): void {
   const name = classObject.name
     .replace(/([A-Z]($|[a-z]))/g, '-$1')
     .replace(/(^-|-Element$)/g, '')
@@ -18,6 +18,11 @@ export function register(classObject: CustomElement): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window[classObject.name] = classObject
-    window.customElements.define(name, classObject)
+
+    if (extendsElement) {
+      window.customElements.define(name, classObject, {extends: extendsElement})
+    } else {
+      window.customElements.define(name, classObject)
+    }
   }
 }


### PR DESCRIPTION
I want to create a custom element and add them to a `<ul>` without breaking some accessibility rules we have on dotcom. A way to achieve that would be by customizing the built in `<li>` element. This PR is my attempt at supporting that behavior.

A simplified example of what would be possible after this patch:

```ts
@controller('li')
class ListItemElement extends HTMLLIElement { ... }
```

```html
<ul>
  <li is="list-item">Item 1</li>
  <li is="list-item">Item 2</li>
  <li is="list-item">Item 3</li>
</ul>
```

#### 📚  References

- [Using custom elements - Customized built-in elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Customized_built-in_elements)
- [I followed this example when overloading the decorator](https://github.com/Microsoft/TypeScript/issues/13173#issuecomment-269246173).