### PR TITLE
Release v0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/catalyst",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/catalyst",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Helpers for creating HTML Elements as Controllers",
   "homepage": "https://github.github.io/catalyst",
   "bugs": {


### PR DESCRIPTION
### Summary 

I've just run into the issue mentioned in https://github.com/github/catalyst/pull/67, as a new version hasn't been released yet this is still a problem in **v0.4.0**. This bumps the version to **v0.4.1** so we can get that sweet bug fix ✨ 


>(main) $ git tag --contains [4c0c5d4d286a3ea3552282aa6a67d25157f646dc](https://github.com/github/catalyst/commit/4c0c5d4d286a3ea3552282aa6a67d25157f646dc)
>(main) $

### TODO:

1. [ ] Tag the release `git tag -a v0.4.0 <SHA>`
2. [ ] Create a new GitHub release 

@keithamus If you'd prefer to cut the release directly to `main` please feel free to close this out or merge it in, up to you 😄 