### PR TITLE
docs: build on separate branch

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -33,4 +33,4 @@ jobs:
         git config --local user.name "Actions Auto Build"
         git add docs/_data/reference.json
         git commit -m "docs: compile reference.json" || true
-        git push
+        git push --force origin HEAD:refs/heads/docs


### PR DESCRIPTION
With branch protection running on the `main` branch, docs needs somewhere else to build to.

This changes the docs CI build to push to a `docs` branch instead, which we can configure to be the pages branch.