### PR TITLE
Publish by default to npm and publish to gpr as a postpublish step

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "clean": "tsc --build --clean",
     "lint": "eslint . --ignore-path .gitignore",
     "pretest": "npm run build",
-    "test": "npm run lint && karma start test/karma.config.cjs"
+    "test": "npm run lint && karma start test/karma.config.cjs",
+    "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'"
   },
   "prettier": "@github/prettier-config",
   "devDependencies": {
@@ -51,8 +52,5 @@
     "tslib": "^2.0.3",
     "typedoc": "^0.19.2",
     "typescript": "^4.0.5"
-  },
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
   }
 }


### PR DESCRIPTION
Now that Catalyst is public, we can put it on npm as a public package. This PR changes the npm registry to `npm` but continues to publish to GitHub Packages in a `postpublish` task.

Reference: #83 