### PR TITLE
Fixing GH code urls in 'Reference guide'

### DIFF
--- a/docs/reference.html
+++ b/docs/reference.html
@@ -15,7 +15,7 @@ title: Reference guide
     <div class="mb-3 f5">
       {% for source in export.sources %}
       Defined in:
-      <a href="{{ site.github.repository_url }}/blob/{{ revision }}/src/{{ source.fileName }}#L{{ source.line }}">
+      <a href="{{ site.github.repository_url }}/blob/{{ revision }}/{{ source.fileName }}#L{{ source.line }}">
         {{ source.fileName }}:{{ source.line }}
       </a>
       {% endfor %}


### PR DESCRIPTION
Example url (on [Reference guide](https://github.github.io/catalyst/reference/)) redirects to:

https://github.com/github/catalyst/blob/0b34644/src/src/auto-shadow-root.ts#L1

rather than to 

https://github.com/github/catalyst/blob/0b34644/src/auto-shadow-root.ts#L1.

