### PR TITLE
Remove "Target" suffix from property in example

### DIFF
--- a/docs/_guide/targets.md
+++ b/docs/_guide/targets.md
@@ -30,10 +30,10 @@ import { controller, target } from "@github/catalyst"
 
 @controller
 class HelloWorldElement extends HTMLElement {
-  @target outputTarget: HTMLElement
+  @target output: HTMLElement
 
   greet() {
-    this.outputTarget.textContent = `Hello, world!`
+    this.output.textContent = `Hello, world!`
   }
 }
 ```


### PR DESCRIPTION
I think this might have been a typo or an old version that matched stimulus more closely.

Example uses:
```html
<hello-world>
  <span
    data-target="hello-world.output">
  </span>
</hello-world>
```

So the property name should be `output` rather than `outputTarget` because `@target` uses the property descriptor's `key` as-is.
https://github.com/github/catalyst/blob/88233801ddc8408ebbbcccd9a4a39de0fd4d7fea/src/target.ts#L10-L17