### PR TITLE
Fix documentation: Match @target names with template data-target

### DIFF
--- a/docs/_guide/actions.md
+++ b/docs/_guide/actions.md
@@ -52,12 +52,12 @@ import { controller, target } from "@github/catalyst"
 
 @controller
 class HelloWorldElement extends HTMLElement {
-  @target nameTarget: HTMLElement
-  @target outputTarget: HTMLElement
+  @target name: HTMLElement
+  @target output: HTMLElement
 
   greet() {
-    this.outputTarget.textContent =
-      `Hello, ${this.nameTarget.value}!`
+    this.output.textContent =
+      `Hello, ${this.name.value}!`
   }
 }
 ```


### PR DESCRIPTION
In the current example in the docs appears:
`data-target="hello-world.name` to be matched with `@target nameTarget: HTMLElement`
where it should be `@target name: HTMLElement`.
and something similar for the target "output"