### PR TITLE
docs: make sidebar sticky

### DIFF
--- a/docs/_includes/reference_sidebar.html
+++ b/docs/_includes/reference_sidebar.html
@@ -1,5 +1,5 @@
 <aside class="col-lg-3 pl-4 pt-1 pb-1 bg-gray">
-  <nav>
+  <nav class="sticky top-100px">
     <ul class="f3-light ml-4">
       {% for item in sidebarItems %}
       <li class="py-1">

--- a/docs/_includes/reference_sidebar.html
+++ b/docs/_includes/reference_sidebar.html
@@ -1,5 +1,5 @@
 <aside class="col-lg-3 pl-4 pt-1 pb-1 bg-gray">
-  <nav class="sticky top-100px">
+  <nav class="position-sticky top-100px">
     <ul class="f3-light ml-4">
       {% for item in sidebarItems %}
       <li class="py-1">

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,5 +1,5 @@
 <aside class="col-lg-3 pl-4 pt-1 pb-1 bg-gray">
-  <nav>
+  <nav class="sticky top-100px">
     <ol class="f3-light ml-4">
       {% for item in sidebarItems %}
       <li class="py-1">

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,5 +1,5 @@
 <aside class="col-lg-3 pl-4 pt-1 pb-1 bg-gray">
-  <nav class="sticky top-100px">
+  <nav class="position-sticky top-100px">
     <ol class="f3-light ml-4">
       {% for item in sidebarItems %}
       <li class="py-1">

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -4,7 +4,6 @@ code { font-size: 90% !important }
 h1, h2, h3, h4, h5 { margin: 1rem 0; width: 100%; }
 ul li { margin-left: 1rem }
 
-.sticky { position: sticky }
 .top-100px { top: 100px }
 
 /* No preference or prefers light */

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -4,6 +4,9 @@ code { font-size: 90% !important }
 h1, h2, h3, h4, h5 { margin: 1rem 0; width: 100%; }
 ul li { margin-left: 1rem }
 
+.sticky { position: sticky }
+.top-100px { top: 100px }
+
 /* No preference or prefers light */
 :root:not([data-prefers-color-scheme=dark]),
 html[data-prefers-color-scheme=light] {


### PR DESCRIPTION
On desktop, some of the longer guide pages as well as the reference page fall below the fold and scrolling down means you lose the sidebar as you scroll.

This PR adds `position:sticky` to the sidebars so that they are always present as you scroll.

Browser support is good for this. Tested in Firefox and Chrome