### PR TITLE
refactor(bind): optimize memory by using WeakSet over Set

### DIFF
--- a/test/bind.js
+++ b/test/bind.js
@@ -204,6 +204,7 @@ describe('bind', () => {
   describe('listenForBind', () => {
     it('re-binds actions that are denoted by HTML that is dynamically injected into the controller', async function () {
       const instance = document.createElement('bind-test-element')
+      bind(instance)
       chai.spy.on(instance, 'foo')
       root.appendChild(instance)
       listenForBind(root)
@@ -278,6 +279,7 @@ describe('bind', () => {
 
   it('re-binds actions deeply in the HTML', async function () {
     const instance = document.createElement('bind-test-element')
+    bind(instance)
     chai.spy.on(instance, 'foo')
     root.appendChild(instance)
     listenForBind(root)


### PR DESCRIPTION
This change switches the `controllers` `Set<string>` in `bind.ts` for a `WeakSet<Element>`. This change is motivated by a desire to store less in memory with the creation of lots of controllers.

The current implementation stores the components tag names in a set. With each new controller it stores an extra string in memory, with one or two controllers this isn't a big deal but over time it adds up.

The new implementation in this PR stores component instances in a WeakSet, effectively holding references to them. This means extra strings are not created per-tag and should result in more stable memory use. The hypothesis is less strings should be stored in memory leading to a lower memory footprint.

I benchmarked the memory usage using the browsers memory snapshot tool with the existing implementation and the new one to compare allocations. I wrote quick benchmark which added 1000 new components to see the impact this had on memory.

<details>
<summary>The code for this benchmark is here:</summary>

```html
<!DOCTYPE html>
<html>
  <head>
    <script type="module">
      import {controller} from './lib/index.js'
      let i = 0
      document.addEventListener('click', () => {
        const start = Date.now()
        const startI = i
        for(; i < startI + 1000; ++i) {
          controller(class extends HTMLElement {
            static get name() { return `FooBar${i}Element` }
          })
        }
        console.log(`Created ${i - startI} in ${Date.now() - start}ms`)
      })
    </script>
  </head>
</html>
```

</details>


Before with strings:
```
Fresh Page: 2.25mb; strings: 228kb 4133, object: 770kb 10264)
+1000: 3.05mb; strings: 287kb 6257, objects: 1mib 15472) (+0.8mb; strings: +59kb +2124, objects: +230kb +5208)
+2000: 3.93mb; strings: 349kb 7256, objects: 1mib 20475) (+0.88mb; strings: +62kb +5003, objects: +0mb +5003)
+3000: 4.75mb; strings: 365kb 8256 objects: 2mib 25438) (+0.82mb; strings: +16kb +1000, objects: +1mb +4963)
Avg Increase: 0.833mb; strings: 45.6kb, 2709, objects: 418kb 5058)
```

After with WeakSet:

```
Fresh Page: 2.24mb (strings: 225kb 4134, object: 773kb 10312)
+1000: 2.96mb (strings: 266kb 5359, objects: 1mib 15479) (+0.69mb; strings: +41kb +1225, objects: +251kb +5167)
+2000: 3.89mb (strings: 328kb 7359, objects: 1mib 20483) (+0.93mb; strings: +62kb +2000, objects: +0mb +5004)
+3000: 4.59mb (strings: 342kb 7258, objects: 2mib 25476) (+0.7mb; strings: 14kb -101, objects: +1mb +4993)
Avg Increase: 0.773mb; strings: 39kb, 1041, objects: 425kb 5054)
```


The benchmarks align pretty closely with expectations: with the creation of 1000 elements, using a `Set<string>` sees the allocation of at least 1000 more strings than using `WeakMap<Element>`. Turns out creating a string puts that string in memory!

We see with each new 1000 elements created, overall the object allocations remain similar but the string count is drastically lower and consequently the memory usage is a little lower. This aren't huge numbers and will likely have very little impact on real world code but it's nice to have as little impact as possible on memory.