### PR TITLE
Set base to base url

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -4,10 +4,14 @@
 <html lang="en" class="height-full">
   <head>
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
+
+    <base href="{{ site.baseurl }}/">
+
     <meta name="description" content="Catalyst is a set of patterns and techniques for developing components within a complex application.">
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <meta name="supported-color-schemes" content="light dark">
+
     <link rel="stylesheet" href="{{ site.baseurl }}/primer.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/github-syntax.css">
     <link rel="stylesheet" href="{{ site.baseurl }}/custom.css">


### PR DESCRIPTION
Should fix font loading issue on production, where primer looks in the root folder for fonts but we need it to look in the `catalyst/` sub directory.