### PR TITLE
Drop test/docs references to requestAnimationFrame

### DIFF
--- a/docs/_guide/actions.md
+++ b/docs/_guide/actions.md
@@ -162,8 +162,6 @@ class HelloWorldElement extends HTMLElement {
 
 Catalyst automatically listens for elements that are dynamically injected into the DOM, and will bind any element's `data-action` attributes. It does this by calling `listenForBind(controller.ownerDocument)`. If for some reason you need to observe other documents (such as mutations within an iframe), then you can call the `listenForBind` manually, passing a `Node` to listen to DOM mutations on.
 
-Batch processing binds events in small batches to maintain UI stability (using `requestAnimationFrame` behind the scenes).
-
 ```js
 import {listenForBind} from '@github/catalyst'
 

--- a/test/bind.js
+++ b/test/bind.js
@@ -1,11 +1,5 @@
 import {bind, listenForBind} from '../lib/bind.js'
 
-async function waitForNextAnimationFrame() {
-  return new Promise(resolve => {
-    window.requestAnimationFrame(resolve)
-  })
-}
-
 describe('bind', () => {
   window.customElements.define('bind-test-element', class extends HTMLElement {})
 
@@ -150,9 +144,9 @@ describe('bind', () => {
     bind(instance)
 
     instance.append(el1, el2)
-    // We need to wait for a couple of frames after injecting the HTML into to
+    // We need to wait for one microtask after injecting the HTML into to
     // controller so that the actions have been bound to the controller.
-    await waitForNextAnimationFrame()
+    await Promise.resolve()
     document.body.removeChild(instance)
 
     expect(instance.foo).to.have.not.been.called()
@@ -190,10 +184,9 @@ describe('bind', () => {
     bind(instance)
     instance.shadowRoot.append(el1)
     instance.shadowRoot.append(el2)
-    // We need to wait for a couple of frames after injecting the HTML into to
+    // We need to wait for one microtask after injecting the HTML into to
     // controller so that the actions have been bound to the controller.
-    await waitForNextAnimationFrame()
-    await waitForNextAnimationFrame()
+    await Promise.resolve()
     expect(instance.foo).to.have.not.been.called()
     el1.click()
     expect(instance.foo).to.have.been.called.exactly(1)
@@ -211,10 +204,9 @@ describe('bind', () => {
       const button = document.createElement('button')
       button.setAttribute('data-action', 'click:bind-test-element#foo')
       instance.appendChild(button)
-      // We need to wait for a couple of frames after injecting the HTML into to
+      // We need to wait for one microtask after injecting the HTML into to
       // controller so that the actions have been bound to the controller.
-      await waitForNextAnimationFrame()
-      await waitForNextAnimationFrame()
+      await Promise.resolve()
       button.click()
       expect(instance.foo).to.have.been.called.exactly(1)
     })
@@ -228,10 +220,9 @@ describe('bind', () => {
       const button = document.createElement('button')
       button.setAttribute('data-action', 'click:bind-test-element#foo')
       instance.appendChild(button)
-      // We need to wait for a couple of frames after injecting the HTML into to
+      // We need to wait for one microtask after injecting the HTML into to
       // controller so that the actions have been bound to the controller.
-      await waitForNextAnimationFrame()
-      await waitForNextAnimationFrame()
+      await Promise.resolve()
       button.click()
       expect(instance.foo).to.have.been.called.exactly(0)
     })
@@ -245,10 +236,9 @@ describe('bind', () => {
       const button = document.createElement('button')
       button.setAttribute('data-action', 'click:bind-test-not-element#foo')
       instance.appendChild(button)
-      // We need to wait for a couple of frames after injecting the HTML into to
+      // We need to wait for one microtask after injecting the HTML into to
       // controller so that the actions have been bound to the controller.
-      await waitForNextAnimationFrame()
-      await waitForNextAnimationFrame()
+      await Promise.resolve()
       button.click()
       expect(instance.foo).to.have.been.called.exactly(0)
     })
@@ -270,8 +260,7 @@ describe('bind', () => {
       instance.appendChild(button)
       root.appendChild(instance)
       // wait for processQueue
-      await waitForNextAnimationFrame()
-      await waitForNextAnimationFrame()
+      await Promise.resolve()
       button.click()
       expect(instance.foo).to.have.been.called.exactly(1)
     })
@@ -290,10 +279,9 @@ describe('bind', () => {
           </div>
         </div>
       `
-    // We need to wait for a couple of frames after injecting the HTML into to
+    // We need to wait for one microtask after injecting the HTML into to
     // controller so that the actions have been bound to the controller.
-    await waitForNextAnimationFrame()
-    await waitForNextAnimationFrame()
+    await Promise.resolve()
     instance.querySelector('button').click()
     expect(instance.foo).to.have.been.called.exactly(1)
   })
@@ -322,12 +310,11 @@ describe('bind', () => {
     instance.appendChild(button)
     bind(instance)
     listenForBind(root)
-    await waitForNextAnimationFrame()
+    await Promise.resolve()
     button.click()
     expect(instance.foo).to.have.been.called.exactly(0)
     button.setAttribute('data-action', 'click:bind-test-element#foo')
-    await waitForNextAnimationFrame()
-    await waitForNextAnimationFrame()
+    await Promise.resolve()
     button.click()
     expect(instance.foo).to.have.been.called.exactly(1)
   })


### PR DESCRIPTION
`listenForBind` used to call `requestAnimationFrame` as it was doing some costly operations during event binding.

We've managed to since optimize this away in #53 but the tests were left unmodified from this change. The code now doesn't explicitly call `requestAnimationFrame`, although the still goes into the event queue due to MutationObserver, so the tests still need to be async.

This PR changes the tests to clean up the messy `rAF` calls, and eliminating the double waits, instead opting for a `await Promise.resolve()`. Awaiting a Promise is enough to push the assertions into the next task in the queue which allows the `MuitationObserver` to fire.

This also updates the docs which commented on this optimization. This removes the comment as it no longer holds true. 