### PR TITLE
Fix typo in the `attr` example

### DIFF
--- a/docs/_guide/attrs.md
+++ b/docs/_guide/attrs.md
@@ -165,7 +165,7 @@ import { controller, attr } from "@github/catalyst"
 class HelloWorldElement extends HTMLElement {
   @attr name = 'World'
   connectedCallback() {
-    this.textContent = `Hello ${name}`
+    this.textContent = `Hello ${this.name}`
   }
 }
 ```


### PR DESCRIPTION
It looks like there's a typo in the example and it should be `this.name` instead of just `name`