### PR TITLE
Lint import statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,13 +5,7 @@
   "rules": {
     "no-invalid-this": "off",
     "@typescript-eslint/no-invalid-this": ["error"],
-    "import/extensions": [
-      "error",
-      "ignorePackages",
-      {
-        "ts": "never"
-      }
-    ],
+    "import/extensions": ["error", "ignorePackages"],
     "@typescript-eslint/consistent-type-imports": ["error", {"prefer": "type-imports"}]
   },
   "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,15 @@
   "extends": ["plugin:github/recommended", "plugin:github/typescript", "plugin:github/browser"],
   "rules": {
     "no-invalid-this": "off",
-    "@typescript-eslint/no-invalid-this": ["error"]
+    "@typescript-eslint/no-invalid-this": ["error"],
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        "ts": "never"
+      }
+    ],
+    "@typescript-eslint/consistent-type-imports": ["error", {"prefer": "type-imports"}]
   },
   "overrides": [
     {

--- a/src/attr.ts
+++ b/src/attr.ts
@@ -1,4 +1,4 @@
-import type {CustomElement} from './custom-element'
+import type {CustomElement} from './custom-element.js'
 
 const attrs = new WeakMap<Record<PropertyKey, unknown>, string[]>()
 type attrValue = string | number | boolean

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,7 +1,7 @@
-import {register} from './register'
-import {bind} from './bind'
-import {autoShadowRoot} from './auto-shadow-root'
-import {defineObservedAttributes, initializeAttrs} from './attr'
+import {register} from './register.js'
+import {bind} from './bind.js'
+import {autoShadowRoot} from './auto-shadow-root.js'
+import {defineObservedAttributes, initializeAttrs} from './attr.js'
 import type {CustomElement} from './custom-element'
 
 /**

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,7 +1,7 @@
 import {register} from './register.js'
 import {bind} from './bind.js'
 import {autoShadowRoot} from './auto-shadow-root.js'
-import {defineObservedAttributes, initializeAttrs} from './attr.ts'
+import {defineObservedAttributes, initializeAttrs} from './attr.js'
 import type {CustomElement} from './custom-element.js'
 
 /**

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,8 +1,8 @@
 import {register} from './register.js'
 import {bind} from './bind.js'
 import {autoShadowRoot} from './auto-shadow-root.js'
-import {defineObservedAttributes, initializeAttrs} from './attr.js'
-import type {CustomElement} from './custom-element'
+import {defineObservedAttributes, initializeAttrs} from './attr.ts'
+import type {CustomElement} from './custom-element.js'
 
 /**
  * Controller is a decorator to be used over a class that extends HTMLElement.

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,7 +1,7 @@
-import {register} from './register.js'
-import {bind} from './bind.js'
-import {autoShadowRoot} from './auto-shadow-root.js'
-import {defineObservedAttributes, initializeAttrs} from './attr.js'
+import {register} from './register'
+import {bind} from './bind'
+import {autoShadowRoot} from './auto-shadow-root'
+import {defineObservedAttributes, initializeAttrs} from './attr'
 import type {CustomElement} from './custom-element'
 
 /**

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,4 +1,4 @@
-import type {CustomElement} from './custom-element'
+import type {CustomElement} from './custom-element.js'
 
 /**
  * Register the controller as a custom element.


### PR DESCRIPTION
Follow up from #120. 

Lint import statements for file extensions and make sure type imports have the `type` keyword.