### PR TITLE
Update method name checker to clear message

### DIFF
--- a/docs/_guide/anti-patterns.md
+++ b/docs/_guide/anti-patterns.md
@@ -142,6 +142,10 @@ When naming a method, you should avoid naming it something that already exists o
       const goodEl = document.querySelector('.js-methodname-shadow-good-input')
       const badEl = document.querySelector('.js-methodname-shadow-bad-input')
       const warnEl = document.querySelector('.js-methodname-shadow-warn-input')
+      if (name === '') {
+        goodEl.hidden = true
+        return
+      }
       let warning = warnings[name]
       if (name !== name.toLowerCase() && name.toLowerCase() in HTMLElement.prototype) {
         warning = `it is too similar to \`${name.toLowerCase()}\` which already exists`
@@ -149,7 +153,7 @@ When naming a method, you should avoid naming it something that already exists o
         warning = 'starting with `on` suggests a coupling between the event and the method (see below)'
       }
       goodEl.hidden = warning || (name in HTMLElement.prototype)
-      warnEl.hidden = !warning 
+      warnEl.hidden = !warning
       badEl.hidden = warning || !(name in HTMLElement.prototype)
       if (warning) {
         warnEl.querySelector('span').textContent = warning


### PR DESCRIPTION
Currently, if the user fills out the form and then empties the field,
they still see the "This is a good name" message. That message should go
away if the input is empty.

<img width="422" alt="Screen Shot 2021-03-05 at 11 16 35 AM" src="https://user-images.githubusercontent.com/2181356/110157625-a2d6e400-7da5-11eb-97bc-871695599a3b.png">

Check it out at https://github-d6c77e0c52.drafts.github.io/catalyst//guide/anti-patterns/