### PR TITLE
Align the declarative shadowroot with specs

### DIFF
--- a/src/auto-shadow-root.ts
+++ b/src/auto-shadow-root.ts
@@ -1,11 +1,18 @@
 export function autoShadowRoot(element: HTMLElement): void {
-  for (const template of element.querySelectorAll<HTMLTemplateElement>('template[shadowroot]')) {
+  for (const template of element.querySelectorAll<HTMLTemplateElement>('template')) {
     if (template.parentElement === element) {
-      element
-        .attachShadow({
-          mode: template.getAttribute('shadowroot') === 'closed' ? 'closed' : 'open'
-        })
-        .append(template.content.cloneNode(true))
+      const prefix = template.hasAttribute('data-shadowroot') ? 'data-' : ''
+
+      if (
+        template.hasAttribute('data-shadowroot') ||
+        (template.hasAttribute('shadowroot') && !HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot'))
+      ) {
+        element
+          .attachShadow({
+            mode: template.getAttribute(`${prefix}shadowroot`) === 'closed' ? 'closed' : 'open'
+          })
+          .append(template.content.cloneNode(true))
+      }
     }
   }
 }

--- a/src/auto-shadow-root.ts
+++ b/src/auto-shadow-root.ts
@@ -1,9 +1,9 @@
 export function autoShadowRoot(element: HTMLElement): void {
-  for (const template of element.querySelectorAll<HTMLTemplateElement>('template[data-shadowroot]')) {
+  for (const template of element.querySelectorAll<HTMLTemplateElement>('template[shadowroot]')) {
     if (template.parentElement === element) {
       element
         .attachShadow({
-          mode: template.getAttribute('data-shadowroot') === 'closed' ? 'closed' : 'open'
+          mode: template.getAttribute('shadowroot') === 'closed' ? 'closed' : 'open'
         })
         .append(template.content.cloneNode(true))
     }

--- a/src/auto-shadow-root.ts
+++ b/src/auto-shadow-root.ts
@@ -5,7 +5,7 @@ export function autoShadowRoot(element: HTMLElement): void {
 
       if (
         template.hasAttribute('data-shadowroot') ||
-        (template.hasAttribute('shadowroot') && !HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot'))
+        (template.hasAttribute('shadowroot') && !HTMLTemplateElement.prototype.hasOwnProperty('shadowroot'))
       ) {
         element
           .attachShadow({

--- a/test/auto-shadow-root.js
+++ b/test/auto-shadow-root.js
@@ -18,6 +18,19 @@ describe('autoShadowRoot', () => {
     const instance = document.createElement('shadowroot-test-element')
     const template = document.createElement('template')
     template.innerHTML = 'Hello World'
+    template.setAttribute('data-shadowroot', 'open')
+    instance.appendChild(template)
+
+    autoShadowRoot(instance)
+
+    expect(instance).to.have.property('shadowRoot').not.equal(null)
+    expect(instance.shadowRoot.textContent).to.equal('Hello World')
+  })
+
+  it('automatically declares shadowroot for elements with `template[shadowroot]` children', () => {
+    const instance = document.createElement('shadowroot-test-element')
+    const template = document.createElement('template')
+    template.innerHTML = 'Hello World'
     template.setAttribute('shadowroot', 'open')
     instance.appendChild(template)
 
@@ -28,6 +41,19 @@ describe('autoShadowRoot', () => {
   })
 
   it('does not attach shadowroot without a template`data-shadowroot` child', () => {
+    const instance = document.createElement('shadowroot-test-element')
+    const template = document.createElement('template')
+    template.setAttribute('data-notshadowroot', 'open')
+    const otherTemplate = document.createElement('div')
+    otherTemplate.setAttribute('data-shadowroot', 'open')
+    instance.appendChild(template, otherTemplate)
+
+    autoShadowRoot(instance)
+
+    expect(instance).to.have.property('shadowRoot').equal(null)
+  })
+
+  it('does not attach shadowroot without a template`shadowroot` child', () => {
     const instance = document.createElement('shadowroot-test-element')
     const template = document.createElement('template')
     template.setAttribute('data-notshadowroot', 'open')
@@ -53,7 +79,20 @@ describe('autoShadowRoot', () => {
     expect(instance).to.have.property('shadowRoot').equal(null)
   })
 
-  it('attaches shadowRoot nodes open by default', () => {
+  it('attaches template[data-shadowRoot] nodes open by default', () => {
+    const instance = document.createElement('shadowroot-test-element')
+    const template = document.createElement('template')
+    template.innerHTML = 'Hello World'
+    template.setAttribute('data-shadowroot', '')
+    instance.appendChild(template)
+
+    autoShadowRoot(instance)
+
+    expect(instance).to.have.property('shadowRoot').not.equal(null)
+    expect(instance.shadowRoot.textContent).to.equal('Hello World')
+  })
+
+  it('attaches template[shadowRoot] nodes open by default', () => {
     const instance = document.createElement('shadowroot-test-element')
     const template = document.createElement('template')
     template.innerHTML = 'Hello World'
@@ -70,7 +109,7 @@ describe('autoShadowRoot', () => {
     const instance = document.createElement('shadowroot-test-element')
     const template = document.createElement('template')
     template.innerHTML = 'Hello World'
-    template.setAttribute('shadowroot', 'closed')
+    template.setAttribute('data-shadowroot', 'closed')
     instance.appendChild(template)
 
     let shadowRoot = null
@@ -84,5 +123,18 @@ describe('autoShadowRoot', () => {
     expect(instance).to.have.property('shadowRoot').equal(null)
     expect(instance.attachShadow).to.have.been.called.once.with.exactly({mode: 'closed'})
     expect(shadowRoot.textContent).to.equal('Hello World')
+  })
+
+  it('attaches template[shadowRoot] nodes open by default', () => {
+    const instance = document.createElement('shadowroot-test-element')
+    const template = document.createElement('template')
+    template.innerHTML = 'Hello World'
+    template.setAttribute('shadowroot', '')
+    instance.appendChild(template)
+
+    autoShadowRoot(instance)
+
+    expect(instance).to.have.property('shadowRoot').not.equal(null)
+    expect(instance.shadowRoot.textContent).to.equal('Hello World')
   })
 })

--- a/test/auto-shadow-root.js
+++ b/test/auto-shadow-root.js
@@ -18,7 +18,7 @@ describe('autoShadowRoot', () => {
     const instance = document.createElement('shadowroot-test-element')
     const template = document.createElement('template')
     template.innerHTML = 'Hello World'
-    template.setAttribute('data-shadowroot', 'open')
+    template.setAttribute('shadowroot', 'open')
     instance.appendChild(template)
 
     autoShadowRoot(instance)
@@ -32,7 +32,7 @@ describe('autoShadowRoot', () => {
     const template = document.createElement('template')
     template.setAttribute('data-notshadowroot', 'open')
     const otherTemplate = document.createElement('div')
-    otherTemplate.setAttribute('data-shadowroot', 'open')
+    otherTemplate.setAttribute('shadowroot', 'open')
     instance.appendChild(template, otherTemplate)
 
     autoShadowRoot(instance)
@@ -57,7 +57,7 @@ describe('autoShadowRoot', () => {
     const instance = document.createElement('shadowroot-test-element')
     const template = document.createElement('template')
     template.innerHTML = 'Hello World'
-    template.setAttribute('data-shadowroot', '')
+    template.setAttribute('shadowroot', '')
     instance.appendChild(template)
 
     autoShadowRoot(instance)
@@ -70,7 +70,7 @@ describe('autoShadowRoot', () => {
     const instance = document.createElement('shadowroot-test-element')
     const template = document.createElement('template')
     template.innerHTML = 'Hello World'
-    template.setAttribute('data-shadowroot', 'closed')
+    template.setAttribute('shadowroot', 'closed')
     instance.appendChild(template)
 
     let shadowRoot = null

--- a/test/controller.js
+++ b/test/controller.js
@@ -62,7 +62,7 @@ describe('controller', () => {
     controller(class ControllerBindAutoShadowElement extends HTMLElement {})
     const instance = document.createElement('controller-bind-auto-shadow')
     const template = document.createElement('template')
-    template.setAttribute('data-shadowroot', 'open')
+    template.setAttribute('shadowroot', 'open')
     // eslint-disable-next-line github/unescaped-html-literal
     template.innerHTML = '<button data-action="click:controller-bind-auto-shadow#foo"></button>'
     instance.appendChild(template)


### PR DESCRIPTION
This PR is using `shadowroot` attribute instead of `data-shadowroot` and should be aligned with the specs (Chrome 90 already shipped this)

Ref: https://web.dev/declarative-shadow-dom/

It might worth changing the logic a bit further here, eg template needs to be the first child element and should be only one template per web-component (if I'm reading correctly the specs)

B/C break!! Probably needs a major version