### PR TITLE
Fix: code of `<pre>` element is displayed protruding.

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -44,7 +44,8 @@ body {
 
 /* Code Blocks & Syntax */
 .markdown-body .highlight pre, .markdown-body pre {
-  background-color: var(--color-bg-canvas-tertiary)
+  background-color: var(--color-bg-canvas-tertiary);
+  overflow: auto;
 }
 
 /* Inline Code */

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -44,8 +44,7 @@ body {
 
 /* Code Blocks & Syntax */
 .markdown-body .highlight pre, .markdown-body pre {
-  background-color: var(--color-bg-canvas-tertiary);
-  overflow: inherit
+  background-color: var(--color-bg-canvas-tertiary)
 }
 
 /* Inline Code */


### PR DESCRIPTION
Hi, I am interested in [the article on developing with Web Components](https://github.blog/2021-05-04-how-we-use-web-components-at-github/). It's been very helpful.

When I was looking at [the Catalyst documentation](https://github.github.io/catalyst/guide/your-first-component/), I found that the code block was displayed in an overflowing manner, which made it difficult to view on a smartphone.

<table>
<tr>
	<td align="center">PC View
	<td align="center">SP View
<tr>
	<td><img width="921" alt="Screen Shot 2021-05-05 at 13 01 34" src="https://user-images.githubusercontent.com/1996642/117096796-0761ef80-ada5-11eb-94bf-eea1df78b11c.png">
	<td><img width="358" alt="Screen Shot 2021-05-05 at 13 01 24" src="https://user-images.githubusercontent.com/1996642/117096814-1052c100-ada5-11eb-9c24-122eedb54e9d.png">
</table>

This is a pull request to fix it.
Please confirm.