### PR TITLE
Fix header not sticking when scrolling down

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,7 +1,7 @@
 ---
 ---
 <!DOCTYPE html>
-<html lang="en" class="height-full">
+<html lang="en">
   <head>
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
     <meta name="description" content="Catalyst is a set of patterns and techniques for developing components within a complex application.">


### PR DESCRIPTION
Fixes an issue with the header not staying stuck to the top of the browser when scrolling larger pages.