### PR TITLE
Add note on using build manglers

### DIFF
--- a/docs/_guide/you-will-need.md
+++ b/docs/_guide/you-will-need.md
@@ -18,3 +18,9 @@ Catalyst uses modern browser standards, and so requires evergreen browsers or ma
  - [`MutationObserver`](https://caniuse.com/#search=MutationObserver). [`mutation-observer`](https://github.com/webmodules/mutation-observer) can polyfill this.
 
 Please note this list may increase over time. Catalyst will never ship with polyfills that add missing browser functionality, but will continue to use the latest Web Standards, and so may require more polyfills as new releases come out.
+
+### Build considerations
+
+When using build tools, some JavaScript minifiers modify the class name that Catalyst relies on. You know you have an issue if you encounter the error `"c" is not a valid custom element name`.
+
+A best practice is to allow class names that end with `Element`. For instance, for Terser, you can use the following config: `{ keep_classnames: /Element$/ }`

--- a/docs/_guide/your-first-component.md
+++ b/docs/_guide/your-first-component.md
@@ -33,10 +33,6 @@ By convention Catalyst controllers end in `Element`; Catalyst will omit this whe
 Remember! A class name _must_ include at least two CamelCased words (not including the `Element` suffix). One-word elements will raise exceptions. Example of good names: `UserListElement`, `SubTaskElement`, `PagerContainerElement`
 {% endcapture %}{% include callout.md %}
 
-{% capture callout %}
-When using build tools, some JavaScript minifiers might modify the class name that Catalyst relies on. A best-practice is to allow classnames that end with `Element`. In particular, for Terser, you can use the following config: `{ keep_classnames: /Element$/ }`
-{% endcapture %}{% include callout.md %}
-
 
 ### What does `@controller` do?
 

--- a/docs/_guide/your-first-component.md
+++ b/docs/_guide/your-first-component.md
@@ -33,6 +33,10 @@ By convention Catalyst controllers end in `Element`; Catalyst will omit this whe
 Remember! A class name _must_ include at least two CamelCased words (not including the `Element` suffix). One-word elements will raise exceptions. Example of good names: `UserListElement`, `SubTaskElement`, `PagerContainerElement`
 {% endcapture %}{% include callout.md %}
 
+{% capture callout %}
+When using build tools, some JavaScript minifiers might modify the class name that Catalyst relies on. A best-practice is to allow classnames that end with `Element`. In particular, for Terser, you can use the following config: `{ keep_classnames: /Element$/ }`
+{% endcapture %}{% include callout.md %}
+
 
 ### What does `@controller` do?
 


### PR DESCRIPTION
Changed the docs to inform about #98.

Things to consider:
- Introduce a warning.md instead of callout.md
- Move the added section to the "Patterns" page (aka Best-Practices)