### PR TITLE
feat: allow controller decorator to accept ElementDefinitionOptions

### DIFF
--- a/src/register.ts
+++ b/src/register.ts
@@ -7,7 +7,7 @@ import type {CustomElement} from './custom-element.js'
  *
  * Example: HelloController => hello-controller
  */
-export function register(classObject: CustomElement): void {
+export function register(classObject: CustomElement, defineOptions: ElementDefinitionOptions = {}): void {
   const name = classObject.name
     .replace(/([A-Z]($|[a-z]))/g, '-$1')
     .replace(/(^-|-Element$)/g, '')
@@ -16,6 +16,6 @@ export function register(classObject: CustomElement): void {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     window[classObject.name] = classObject
-    window.customElements.define(name, classObject)
+    window.customElements.define(name, classObject, defineOptions)
   }
 }

--- a/test/controller.js
+++ b/test/controller.js
@@ -9,6 +9,15 @@ describe('controller', () => {
     expect(instance).to.be.instanceof(ControllerRegisterElement)
   })
 
+  it('calls register with extends', () => {
+    class ControllerRegisterExtendsElement extends HTMLAnchorElement {}
+    controller({extends: 'a'})(ControllerRegisterExtendsElement)
+    const instance = document.createElement('a', {is: 'controller-register-extends'})
+    document.body.appendChild(instance)
+    expect(instance).to.be.instanceof(HTMLAnchorElement)
+    expect(instance).to.be.instanceof(ControllerRegisterExtendsElement)
+  })
+
   it('adds data-catalyst to elements', async () => {
     controller(class ControllerDataAttrElement extends HTMLElement {})
     const instance = document.createElement('controller-data-attr')


### PR DESCRIPTION
Fixes #148 

To allow extending native elements with the `@controller` decorator, this PR allows for passing `ElementDefinitionOptions` to the decorator and treating it like a [decorator factory](https://www.typescriptlang.org/docs/handbook/decorators.html#decorator-factories). 

Regular usage of the decorator will still work, so this _should not_ be a breaking change. 
