### PR TITLE
Update reference to lhci CLI & speed up lighthouse runs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -51,7 +51,7 @@ jobs:
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Lighthouse CI
-        run: npx lhci autorun
+        run: npx @lhci/cli@0.7.x autorun
         env:
           JEKYLL_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LHCI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -2,7 +2,8 @@
   "ci": {
     "collect": {
       "url": ["http://localhost:4000/?prefers-color-scheme=light", "http://localhost:4000/?prefers-color-scheme=dark"],
-      "startServerCommand": "cd docs && bundle exec jekyll serve"
+      "startServerCommand": "cd docs && bundle exec jekyll serve",
+      "startServerReadyPattern": "Server running..."
     },
     "assert": {
       "preset": "lighthouse:no-pwa",


### PR DESCRIPTION
The Lighthouse CI CLI is now published as `@lhci/cli`, so we need to update that reference. Additionally, 52cbc43 speeds up the lighthouse run from ~6minutes to ~2minutes because the Lighthouse CI now knows when the server is up and running 