### PR TITLE
Remove reference to invalid "hover" action in Documentation

### DIFF
--- a/docs/_guide/actions.md
+++ b/docs/_guide/actions.md
@@ -94,7 +94,7 @@ data-action: Fires all of these methods depending on the event
       data-action="
         click:hello-world#greetSomeone
         click:analytics-tracking#click
-        hover:analytics-tracking#hover
+        mouseover:analytics-tracking#hover
       "
     >
       Greet Someone


### PR DESCRIPTION
In reading the docs and learning more about actions in Catalyst, I saw that there was a reference to a `hover` action being bound to an element. I tried binding the hover action to an element myself and found it wasn't working. So I looked at [bind.ts](https://github.com/github/catalyst/blob/main/src/bind.ts) and saw that Action bindings are only JS element events (click, mouseover, mousedown etc) so `hover` is invalid.

This is just a documentation change, so no tests were added. I tested the `hover` -> `mouseover` change myself and saw that my action was firing on hover.