### PR TITLE
Remove attrs when controller is disconnected

### DIFF
--- a/src/attr.ts
+++ b/src/attr.ts
@@ -66,6 +66,7 @@ export function initializeAttrs(instance: HTMLElement, names?: Iterable<string>)
         }
       }
     }
+    descriptor.configurable = true
     Object.defineProperty(instance, key, descriptor)
     if (key in instance && !instance.hasAttribute(name)) {
       descriptor.set!.call(instance, value)

--- a/src/attr.ts
+++ b/src/attr.ts
@@ -74,6 +74,15 @@ export function initializeAttrs(instance: HTMLElement, names?: Iterable<string>)
   }
 }
 
+export function removeAttrs(instance: HTMLElement, names?: Iterable<string>): void {
+  if (!names) names = getAttrNames(Object.getPrototypeOf(instance))
+  for (const key of names) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    delete instance[key]
+  }
+}
+
 function getAttrNames(classObjectProto: Record<PropertyKey, unknown>): Set<string> {
   const names: Set<string> = new Set()
   let proto: Record<PropertyKey, unknown> | typeof HTMLElement = classObjectProto

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,7 +1,7 @@
 import {register} from './register.js'
 import {bind, bindShadow} from './bind.js'
 import {autoShadowRoot} from './auto-shadow-root.js'
-import {defineObservedAttributes, initializeAttrs} from './attr.js'
+import {defineObservedAttributes, initializeAttrs, removeAttrs} from './attr.js'
 import type {CustomElement} from './custom-element.js'
 
 /**
@@ -22,4 +22,10 @@ export function controller(classObject: CustomElement): void {
   }
   defineObservedAttributes(classObject)
   register(classObject)
+
+  const disconnect = classObject.prototype.disconnectedCallback
+  classObject.prototype.disconnectedCallback = function (this: HTMLElement) {
+    removeAttrs(this)
+    if (disconnect) disconnect.call(this)
+  }
 }

--- a/test/attr.js
+++ b/test/attr.js
@@ -1,4 +1,4 @@
-import {initializeAttrs, defineObservedAttributes, attr} from '../lib/attr.js'
+import {initializeAttrs, removeAttrs, defineObservedAttributes, attr} from '../lib/attr.js'
 
 describe('initializeAttrs', () => {
   class InitializeAttrTestElement extends HTMLElement {}
@@ -9,6 +9,15 @@ describe('initializeAttrs', () => {
     expect(instance).to.not.have.ownPropertyDescriptor('foo')
     initializeAttrs(instance, ['foo'])
     expect(instance).to.have.ownPropertyDescriptor('foo')
+  })
+
+  it('removes any getter/setter pair that were set for each given attr name', () => {
+    const instance = document.createElement('initialize-attr-test-element')
+    expect(instance).to.not.have.ownPropertyDescriptor('foo')
+    initializeAttrs(instance, ['foo'])
+    expect(instance).to.have.ownPropertyDescriptor('foo')
+    removeAttrs(instance, ['foo'])
+    expect(instance).to.not.have.ownPropertyDescriptor('foo')
   })
 
   it('reflects the `data-*` attribute name of the given key', () => {


### PR DESCRIPTION
When a Catalyst element with defined attrs is re-connected to the DOM, an error occurs when initialising the attrs. This happens because we've already defined the properties on the element, and since the properties aren't configurable, the browser throws an error about re-defining the property.

The following Web Component code demonstrates the problem:

```js
window.customElements.define(
  "my-component",
  class extends HTMLElement {
    connectedCallback() {
      console.log("connected");
      Object.defineProperty(this, "foo", {
        get() {
          return "bar";
        },
        set() {},
      });
    }
    disconnectedCallback() {
      console.log("disconnected");
    }
  }
);

const button = document.querySelector("button");
button?.addEventListener("click", () => {
  const el = document.querySelector("my-component");
  el.remove();
  document.body.appendChild(el);
});
```

When the button is clicked, we'll disconnect the once connected component; it will retain the property that we defined, and once we re-connect the element, the browser throws an error. This is a simplified version of what is happening in Catalyst.

This pull request implements a `diconnectedCallback` method that iterates through the attrs that have been defined and removes them from the element, essentially the inverse of `initializeAttrs`. 