### PR TITLE
Refactor controller contents into `src/core`

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -1,9 +1,5 @@
-import {register} from './register.js'
-import {bind, bindShadow} from './bind.js'
-import {autoShadowRoot} from './auto-shadow-root.js'
-import {defineObservedAttributes, initializeAttrs} from './attr.js'
+import {initializeInstance, initializeClass} from './core.js'
 import type {CustomElement} from './custom-element.js'
-
 /**
  * Controller is a decorator to be used over a class that extends HTMLElement.
  * It will automatically `register()` the component in the customElement
@@ -13,13 +9,7 @@ import type {CustomElement} from './custom-element.js'
 export function controller(classObject: CustomElement): void {
   const connect = classObject.prototype.connectedCallback
   classObject.prototype.connectedCallback = function (this: HTMLElement) {
-    this.toggleAttribute('data-catalyst', true)
-    autoShadowRoot(this)
-    initializeAttrs(this)
-    bind(this)
-    if (connect) connect.call(this)
-    if (this.shadowRoot) bindShadow(this.shadowRoot)
+    initializeInstance(this, connect)
   }
-  defineObservedAttributes(classObject)
-  register(classObject)
+  initializeClass(classObject)
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,26 @@
+import {register} from './register.js'
+import {bind, bindShadow} from './bind.js'
+import {autoShadowRoot} from './auto-shadow-root.js'
+import {defineObservedAttributes, initializeAttrs} from './attr.js'
+import type {CustomElement} from './custom-element.js'
+
+const instances = new WeakSet<Element>()
+
+export function initializeInstance(instance: HTMLElement, connect?: (this: HTMLElement) => void): void {
+  instance.toggleAttribute('data-catalyst', true)
+  instances.add(instance)
+  autoShadowRoot(instance)
+  initializeAttrs(instance)
+  bind(instance)
+  if (connect) connect.call(instance)
+  if (instance.shadowRoot) bindShadow(instance.shadowRoot)
+}
+
+export function initializeClass(classObject: CustomElement): void {
+  defineObservedAttributes(classObject)
+  register(classObject)
+}
+
+export function initialized(el: Element): boolean {
+  return instances.has(el)
+}


### PR DESCRIPTION
This keeps `controller` as a simple decorator.

This enables us to be a little more flexible for future code. 