### PR TITLE
Make sure child decendants are upgraded in connected callback

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -9,7 +9,6 @@ import type {CustomElement} from './custom-element.js'
 export function controller(classObject: CustomElement): void {
   const connect = classObject.prototype.connectedCallback
   classObject.prototype.connectedCallback = function (this: HTMLElement) {
-    customElements.upgrade(this)
     initializeInstance(this, connect)
   }
   initializeClass(classObject)

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -9,6 +9,7 @@ import type {CustomElement} from './custom-element.js'
 export function controller(classObject: CustomElement): void {
   const connect = classObject.prototype.connectedCallback
   classObject.prototype.connectedCallback = function (this: HTMLElement) {
+    customElements.upgrade(this)
     initializeInstance(this, connect)
   }
   initializeClass(classObject)

--- a/src/core.ts
+++ b/src/core.ts
@@ -8,6 +8,7 @@ const instances = new WeakSet<Element>()
 
 export function initializeInstance(instance: HTMLElement, connect?: (this: HTMLElement) => void): void {
   instance.toggleAttribute('data-catalyst', true)
+  customElements.upgrade(instance)
   instances.add(instance)
   autoShadowRoot(instance)
   initializeAttrs(instance)

--- a/test/controller.js
+++ b/test/controller.js
@@ -1,6 +1,17 @@
 import {controller} from '../lib/controller.js'
 
 describe('controller', () => {
+  let root
+
+  beforeEach(() => {
+    root = document.createElement('div')
+    document.body.appendChild(root)
+  })
+
+  afterEach(() => {
+    root.remove()
+  })
+
   it('calls register', async () => {
     class ControllerRegisterElement extends HTMLElement {}
     controller(ControllerRegisterElement)

--- a/test/controller.js
+++ b/test/controller.js
@@ -16,14 +16,14 @@ describe('controller', () => {
     class ControllerRegisterElement extends HTMLElement {}
     controller(ControllerRegisterElement)
     const instance = document.createElement('controller-register')
-    document.body.appendChild(instance)
+    root.appendChild(instance)
     expect(instance).to.be.instanceof(ControllerRegisterElement)
   })
 
   it('adds data-catalyst to elements', async () => {
     controller(class ControllerDataAttrElement extends HTMLElement {})
     const instance = document.createElement('controller-data-attr')
-    document.body.appendChild(instance)
+    root.appendChild(instance)
     expect(instance.hasAttribute('data-catalyst')).to.equal(true)
     expect(instance.getAttribute('data-catalyst')).to.equal('')
   })
@@ -40,7 +40,7 @@ describe('controller', () => {
 
     const instance = document.createElement('controller-bind-order')
     chai.spy.on(instance, 'foo')
-    document.body.appendChild(instance)
+    root.appendChild(instance)
 
     const sub = document.createElement('controller-bind-order-sub')
     sub.setAttribute('data-action', 'loaded:controller-bind-order#foo')
@@ -62,7 +62,7 @@ describe('controller', () => {
     )
     const instance = document.createElement('controller-bind-shadow')
     chai.spy.on(instance, 'foo')
-    document.body.appendChild(instance)
+    root.appendChild(instance)
 
     instance.shadowRoot.querySelector('button').click()
 
@@ -78,7 +78,7 @@ describe('controller', () => {
     template.innerHTML = '<button data-action="click:controller-bind-auto-shadow#foo"></button>'
     instance.appendChild(template)
     chai.spy.on(instance, 'foo')
-    document.body.appendChild(instance)
+    root.appendChild(instance)
 
     expect(instance.shadowRoot).to.exist
     expect(instance).to.have.property('shadowRoot').not.equal(null)

--- a/test/controller.js
+++ b/test/controller.js
@@ -90,6 +90,6 @@ describe('controller', () => {
     )
 
     // eslint-disable-next-line github/unescaped-html-literal
-    document.body.innerHTML = '<parent-element><child-element></child-element></parent-element>'
+    root.innerHTML = '<parent-element><child-element></child-element></parent-element>'
   })
 })

--- a/test/controller.js
+++ b/test/controller.js
@@ -76,4 +76,20 @@ describe('controller', () => {
 
     expect(instance.foo).to.have.been.called(1)
   })
+
+  it('upgrades child decendants when connected', done => {
+    controller(class ChildElementElement extends HTMLElement {})
+    controller(
+      class ParentElementElement extends HTMLElement {
+        connectedCallback() {
+          const child = this.querySelector('child-element')
+          expect(child.matches(':defined')).to.equal(true)
+          done()
+        }
+      }
+    )
+
+    // eslint-disable-next-line github/unescaped-html-literal
+    document.body.innerHTML = '<parent-element><child-element></child-element></parent-element>'
+  })
 })

--- a/test/controller.js
+++ b/test/controller.js
@@ -77,14 +77,13 @@ describe('controller', () => {
     expect(instance.foo).to.have.been.called(1)
   })
 
-  it('upgrades child decendants when connected', done => {
+  it('upgrades child decendants when connected', () => {
     controller(class ChildElementElement extends HTMLElement {})
     controller(
       class ParentElementElement extends HTMLElement {
         connectedCallback() {
           const child = this.querySelector('child-element')
           expect(child.matches(':defined')).to.equal(true)
-          done()
         }
       }
     )


### PR DESCRIPTION
When querying for custom element descendants using `this.querySelector` or Catalyst targets, it's possible to be in a state where a parent custom element can be defined, but its children are not.

Consider the following example:

```js
customElements.define('parent-element', class extends HTMLElement {
  connectedCallback() {
    const child = this.querySelector('child-element')
    console.log(child.getString()) // This will throw since `<child-element>` hasn't been upgraded and is a unknown element.
    console.log(child.matches(':defined')) // false
  }
}
customElements.define('child-element', class extends HTMLElement {
  getString() {
    return 'Hello world'
  }
})

document.body.innerHTML = '<parent-element><child-element></child-element></parent-element>'
````

There's no guarantee that a descendant element has been upgraded when the `connectedCallback` of a parent is executed.

We should make sure that all descendants are upgraded when connectedCallback is executed so that developers can access functions and attributes on those without errors. 

This PR achieves this by upgrading itself and its descendants using `customElements.upgrade(this)`.

### Performance considerations

Running `customElements.upgrade(this)` seems like a bit of an overkill and might therefore have some performance issues but running rudimentary performance testing seems to indicate that it shouldn't be an issue.

This script generates 1000 custom elements as children of a parent element and then calls `customElements.upgrade(this)` 1000 times in it's `connectedCallback`. The script runs at ~60ms on Firefox locally.

```js
      customElements.define('element-a', class extends HTMLElement {
        connectedCallback() {
          const start = performance.now()
          for (let i = 0; i <= 1000; i++) {
            customElements.upgrade(this)
          }
          console.log(`Called customElements.upgrade a thousand times in: ${performance.now() - start}ms`)
        }
      });
      for (let i = 0; i <= 1000; i++) {
        customElements.define(`element-${i}`, class extends HTMLElement {});
      }
      document.body.innerHTML = `
        <element-a>
          ${Array.from({ length: 1000 }, (_, i) => `<element-${i}></element-${i}>`).join('')}
        </element-a>`
```

Additionally, I patched this PR into an application that does HTML fetching and injecting into frames with many DOM nodes. The time it took to run `customElements.upgrade(this)` was never higher than 20ms for a custom element. We could lower this number by only upgrading elements that are about to be called through attrs in Catalyst, but this feels like a correct solution since this will work for plain `.querySelector(..)` calls as well.

### References

https://developer.mozilla.org/en-US/docs/Web/CSS/:defined
https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/upgrade