### PR TITLE
Clean up tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,5 +26,9 @@ jobs:
         node-version: 13.11.0
     - name: Install dependencies
       run: npm i
+    - name: Lint Codebase
+      run: npm run lint
     - name: Run Node.js Tests
       run: npm run test
+    - name: Check Bundle Size
+      run: npm run size

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'",
     "presize": "npm run build",
     "size": "size-limit",
-    "pretest": "npm run size && npm run lint",
     "test": "web-test-runner test/* --node-resolve"
   },
   "prettier": "@github/prettier-config",

--- a/test/attr.ts
+++ b/test/attr.ts
@@ -1,19 +1,22 @@
-import {expect} from '@open-wc/testing'
+import {expect, fixture, html} from '@open-wc/testing'
 import {initializeAttrs, defineObservedAttributes, attr} from '../src/attr.js'
 
 describe('initializeAttrs', () => {
   class InitializeAttrTestElement extends HTMLElement {}
   window.customElements.define('initialize-attr-test-element', InitializeAttrTestElement)
 
+  let instance
+  beforeEach(async () => {
+    instance = await fixture(html`<initialize-attr-test-element />`)
+  })
+
   it('creates a getter/setter pair for each given attr name', () => {
-    const instance = document.createElement('initialize-attr-test-element')
     expect(instance).to.not.have.ownPropertyDescriptor('foo')
     initializeAttrs(instance, ['foo'])
     expect(instance).to.have.ownPropertyDescriptor('foo')
   })
 
   it('reflects the `data-*` attribute name of the given key', () => {
-    const instance = document.createElement('initialize-attr-test-element')
     initializeAttrs(instance, ['foo'])
     expect(instance.foo).to.equal('')
     instance.foo = 'bar'
@@ -24,7 +27,6 @@ describe('initializeAttrs', () => {
   })
 
   it('sets the attribute to a previously defined value on the key', () => {
-    const instance = document.createElement('initialize-attr-test-element')
     instance.foo = 'hello'
     initializeAttrs(instance, ['foo'])
     expect(instance.foo).to.equal('hello')
@@ -33,7 +35,6 @@ describe('initializeAttrs', () => {
   })
 
   it('prioritises the value in the attribute over the property', () => {
-    const instance = document.createElement('initialize-attr-test-element')
     instance.foo = 'goodbye'
     instance.setAttribute('data-foo', 'hello')
     initializeAttrs(instance, ['foo'])
@@ -44,7 +45,6 @@ describe('initializeAttrs', () => {
 
   describe('types', () => {
     it('infers number types from property and casts as number always', () => {
-      const instance = document.createElement('initialize-attr-test-element')
       instance.foo = 1
       initializeAttrs(instance, ['foo'])
       expect(instance.foo).to.equal(1)
@@ -63,7 +63,6 @@ describe('initializeAttrs', () => {
     })
 
     it('infers boolean types from property and uses has/toggleAttribute', () => {
-      const instance = document.createElement('initialize-attr-test-element')
       instance.foo = false
       initializeAttrs(instance, ['foo'])
       expect(instance.foo).to.equal(false)
@@ -86,7 +85,6 @@ describe('initializeAttrs', () => {
     })
 
     it('defaults to inferring string type for non-boolean non-number types', () => {
-      const instance = document.createElement('initialize-attr-test-element')
       instance.foo = /^a regexp$/
       initializeAttrs(instance, ['foo'])
       expect(instance.foo).to.equal('/^a regexp$/')
@@ -97,7 +95,6 @@ describe('initializeAttrs', () => {
 
   describe('naming', () => {
     it('converts camel cased property names to their HTML dasherized equivalents', () => {
-      const instance = document.createElement('initialize-attr-test-element')
       initializeAttrs(instance, ['fooBarBazBing'])
       expect(instance.fooBarBazBing).to.equal('')
       instance.fooBarBazBing = 'bar'
@@ -105,7 +102,6 @@ describe('initializeAttrs', () => {
     })
 
     it('will intuitively dasherize acryonyms', () => {
-      const instance = document.createElement('initialize-attr-test-element')
       initializeAttrs(instance, ['URLBar'])
       expect(instance.URLBar).to.equal('')
       instance.URLBar = 'bar'
@@ -113,7 +109,6 @@ describe('initializeAttrs', () => {
     })
 
     it('dasherizes cap suffixed names correctly', () => {
-      const instance = document.createElement('initialize-attr-test-element')
       initializeAttrs(instance, ['ClipX'])
       expect(instance.ClipX).to.equal('')
       instance.ClipX = 'bar'
@@ -127,8 +122,11 @@ describe('initializeAttrs', () => {
     }
     customElements.define('class-field-attr-test-element', ClassFieldAttrTestElement)
 
+    beforeEach(async () => {
+      instance = await fixture(html`<class-field-attr-test-element />`)
+    })
+
     it('overrides any getters assigned in constructor (like class fields)', () => {
-      const instance = document.createElement('class-field-attr-test-element')
       initializeAttrs(instance, ['foo'])
       instance.foo = 2
       expect(instance.foo).to.equal(2)
@@ -138,14 +136,12 @@ describe('initializeAttrs', () => {
     })
 
     it('defaults to class field value attribute not present', () => {
-      const instance = document.createElement('class-field-attr-test-element')
       initializeAttrs(instance, ['foo'])
       expect(instance.foo).to.equal(1)
       expect(instance.getAttribute('data-foo')).to.equal('1')
     })
 
     it('ignores class field value if element has attribute already', () => {
-      const instance = document.createElement('class-field-attr-test-element')
       instance.setAttribute('data-foo', '2')
       initializeAttrs(instance, ['foo'])
       expect(instance.foo).to.equal(2)
@@ -166,8 +162,12 @@ describe('attr', () => {
   }
   window.customElements.define('extended-attr-test-element', ExtendedAttrTestElement)
 
+  let instance
+  beforeEach(async () => {
+    instance = await fixture(html`<attr-test-element />`)
+  })
+
   it('populates the "default" list for initializeAttrs', () => {
-    const instance = document.createElement('attr-test-element')
     instance.foo = 'hello'
     initializeAttrs(instance)
     expect(instance).to.have.property('foo', 'hello')
@@ -177,8 +177,8 @@ describe('attr', () => {
     expect(instance.getAttribute('data-bar')).to.equal('')
   })
 
-  it('includes attrs from extended elements', () => {
-    const instance = document.createElement('extended-attr-test-element')
+  it('includes attrs from extended elements', async () => {
+    instance = await fixture(html`<extended-attr-test-element />`)
     instance.bar = 'hello'
     instance.baz = 'world'
     initializeAttrs(instance)
@@ -191,8 +191,8 @@ describe('attr', () => {
     expect(instance.getAttribute('data-baz')).to.equal('world')
   })
 
-  it('can be initialized multiple times without error', () => {
-    const instance = document.createElement('initialize-attr-test-element')
+  it('can be initialized multiple times without error', async () => {
+    instance = await fixture(html`<initialize-attr-test-element />`)
     expect(instance).to.not.have.ownPropertyDescriptor('foo')
     initializeAttrs(instance, ['foo'])
     expect(instance).to.have.ownPropertyDescriptor('foo')

--- a/test/attr.ts
+++ b/test/attr.ts
@@ -1,5 +1,5 @@
 import {expect} from '@open-wc/testing'
-import {initializeAttrs, defineObservedAttributes, attr} from '../lib/attr.js'
+import {initializeAttrs, defineObservedAttributes, attr} from '../src/attr.js'
 
 describe('initializeAttrs', () => {
   class InitializeAttrTestElement extends HTMLElement {}

--- a/test/auto-shadow-root.ts
+++ b/test/auto-shadow-root.ts
@@ -1,6 +1,6 @@
 import {expect} from '@open-wc/testing'
 import {replace, fake} from 'sinon'
-import {autoShadowRoot} from '../lib/auto-shadow-root.js'
+import {autoShadowRoot} from '../src/auto-shadow-root.js'
 
 describe('autoShadowRoot', () => {
   window.customElements.define('autoshadowroot-test-element', class extends HTMLElement {})

--- a/test/auto-shadow-root.ts
+++ b/test/auto-shadow-root.ts
@@ -1,27 +1,52 @@
-import {expect} from '@open-wc/testing'
+import {expect, fixture, html} from '@open-wc/testing'
 import {replace, fake} from 'sinon'
 import {autoShadowRoot} from '../src/auto-shadow-root.js'
 
 describe('autoShadowRoot', () => {
-  window.customElements.define('autoshadowroot-test-element', class extends HTMLElement {})
+  window.customElements.define('shadowroot-test-element', class extends HTMLElement {})
 
-  let root
-
-  beforeEach(() => {
-    root = document.createElement('div')
-    document.body.appendChild(root)
+  let instance
+  beforeEach(async () => {
+    instance = await fixture(html`<shadowroot-test-element />`)
   })
 
-  afterEach(() => {
-    root.remove()
+  it('automatically declares shadowroot for elements with `template[data-shadowroot]` children', async () => {
+    instance = await fixture(html`<shadowroot-test-element>
+      <template data-shadowroot="open">Hello World</template>
+    </shadowroot-test-element>`)
+    autoShadowRoot(instance)
+
+    expect(instance).to.have.property('shadowRoot').not.equal(null)
+    expect(instance.shadowRoot.textContent).to.equal('Hello World')
   })
 
-  it('automatically declares shadowroot for elements with `template[data-shadowroot]` children', () => {
-    const instance = document.createElement('shadowroot-test-element')
-    const template = document.createElement('template')
-    template.innerHTML = 'Hello World'
-    template.setAttribute('data-shadowroot', 'open')
-    instance.appendChild(template)
+  it('does not attach shadowroot without a template`data-shadowroot` child', async () => {
+    instance = await fixture(html`<shadowroot-test-element>
+      <template data-notshadowroot="open">Hello</template>
+      <div data-shadowroot="open">World</div>
+    </shadowroot-test-element>`)
+
+    autoShadowRoot(instance)
+
+    expect(instance).to.have.property('shadowRoot').equal(null)
+  })
+
+  it('does not attach shadowroots which are not direct children of the element', async () => {
+    instance = await fixture(html`<shadowroot-test-element>
+      <div>
+        <template data-shadowroot="open">Hello World</template>
+      </div>
+    </shadowroot-test-element>`)
+
+    autoShadowRoot(instance)
+
+    expect(instance).to.have.property('shadowRoot').equal(null)
+  })
+
+  it('attaches shadowRoot nodes open by default', async () => {
+    instance = await fixture(html`<shadowroot-test-element>
+      <template data-shadowroot>Hello World</template>
+    </shadowroot-test-element>`)
 
     autoShadowRoot(instance)
 
@@ -29,52 +54,10 @@ describe('autoShadowRoot', () => {
     expect(instance.shadowRoot.textContent).to.equal('Hello World')
   })
 
-  it('does not attach shadowroot without a template`data-shadowroot` child', () => {
-    const instance = document.createElement('shadowroot-test-element')
-    const template = document.createElement('template')
-    template.setAttribute('data-notshadowroot', 'open')
-    const otherTemplate = document.createElement('div')
-    otherTemplate.setAttribute('data-shadowroot', 'open')
-    instance.appendChild(template, otherTemplate)
-
-    autoShadowRoot(instance)
-
-    expect(instance).to.have.property('shadowRoot').equal(null)
-  })
-
-  it('does not attach shadowroots which are not direct children of the element', () => {
-    const instance = document.createElement('shadowroot-test-element')
-    const div = document.createElement('div')
-    const template = document.createElement('template')
-    template.setAttribute('data-notshadowroot', 'open')
-    div.appendChild(template)
-    instance.appendChild(div)
-
-    autoShadowRoot(instance)
-
-    expect(instance).to.have.property('shadowRoot').equal(null)
-  })
-
-  it('attaches shadowRoot nodes open by default', () => {
-    const instance = document.createElement('shadowroot-test-element')
-    const template = document.createElement('template')
-    template.innerHTML = 'Hello World'
-    template.setAttribute('data-shadowroot', '')
-    instance.appendChild(template)
-
-    autoShadowRoot(instance)
-
-    expect(instance).to.have.property('shadowRoot').not.equal(null)
-    expect(instance.shadowRoot.textContent).to.equal('Hello World')
-  })
-
-  it('attaches shadowRoot nodes closed if `data-shadowroot` is `closed`', () => {
-    const instance = document.createElement('shadowroot-test-element')
-    const template = document.createElement('template')
-    template.innerHTML = 'Hello World'
-    template.setAttribute('data-shadowroot', 'closed')
-    instance.appendChild(template)
-
+  it('attaches shadowRoot nodes closed if `data-shadowroot` is `closed`', async () => {
+    instance = await fixture(html`<shadowroot-test-element>
+      <template data-shadowroot="closed">Hello World</template>
+    </shadowroot-test-element>`)
     let shadowRoot = null
     replace(
       instance,
@@ -89,6 +72,6 @@ describe('autoShadowRoot', () => {
 
     expect(instance).to.have.property('shadowRoot').equal(null)
     expect(instance.attachShadow).to.have.been.calledOnceWith({mode: 'closed'})
-    expect(shadowRoot.textContent).to.equal('Hello World')
+    expect(shadowRoot!.textContent).to.equal('Hello World')
   })
 })

--- a/test/bind.ts
+++ b/test/bind.ts
@@ -1,4 +1,4 @@
-import {expect} from '@open-wc/testing'
+import {expect, fixture, html} from '@open-wc/testing'
 import {replace, fake} from 'sinon'
 import {bind, listenForBind} from '../src/bind.js'
 
@@ -6,32 +6,18 @@ describe('bind', () => {
   window.customElements.define(
     'bind-test-element',
     class extends HTMLElement {
-      foo() {
-        return 'foo'
-      }
-      bar() {
-        return 'bar'
-      }
-      handleEvent() {
-        return 'handleEvent'
-      }
+      foo = fake()
+      bar = fake()
+      handleEvent = fake()
     }
   )
 
-  let root
-
-  beforeEach(() => {
-    root = document.createElement('div')
-    document.body.appendChild(root)
-  })
-
-  afterEach(() => {
-    root.remove()
+  let instance
+  beforeEach(async () => {
+    instance = await fixture(html`<bind-test-element />`)
   })
 
   it('binds events on elements based on their data-action attribute', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el = document.createElement('div')
     el.setAttribute('data-action', 'click:bind-test-element#foo')
     instance.appendChild(el)
@@ -42,8 +28,6 @@ describe('bind', () => {
   })
 
   it('allows for the presence of `:` in an event name', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el = document.createElement('div')
     el.setAttribute('data-action', 'custom:event:bind-test-element#foo')
     instance.appendChild(el)
@@ -54,8 +38,6 @@ describe('bind', () => {
   })
 
   it('binds events on the controller to itself', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     instance.setAttribute('data-action', 'click:bind-test-element#foo')
     bind(instance)
     expect(instance.foo).to.have.callCount(0)
@@ -64,8 +46,6 @@ describe('bind', () => {
   })
 
   it('does not bind elements whose closest selector is not this controller', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el = document.createElement('div')
     el.getAttribute('data-action', 'click:bind-test-element#foo')
     const container = document.createElement('div')
@@ -76,8 +56,6 @@ describe('bind', () => {
   })
 
   it('does not bind elements whose data-action does not match controller tagname', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el = document.createElement('div')
     el.setAttribute('data-action', 'click:other-controller#foo')
     instance.appendChild(el)
@@ -88,8 +66,6 @@ describe('bind', () => {
   })
 
   it('does not bind methods that dont exist', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el = document.createElement('div')
     el.setAttribute('data-action', 'click:bind-test-element#frob')
     instance.appendChild(el)
@@ -99,8 +75,6 @@ describe('bind', () => {
   })
 
   it('can bind multiple event types', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el = document.createElement('div')
     el.setAttribute('data-action', 'click:bind-test-element#foo submit:bind-test-element#foo')
     instance.appendChild(el)
@@ -115,8 +89,6 @@ describe('bind', () => {
   })
 
   it('binds to `handleEvent` is function name is omitted', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'handleEvent', fake(instance.handleEvent))
     const el = document.createElement('div')
     el.setAttribute('data-action', 'click:bind-test-element submit:bind-test-element')
     instance.appendChild(el)
@@ -131,9 +103,6 @@ describe('bind', () => {
   })
 
   it('can bind multiple actions separated by line feed', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
-    replace(instance, 'bar', fake(instance.bar))
     const el = document.createElement('div')
     el.setAttribute('data-action', `click:bind-test-element#foo\nclick:bind-test-element#bar`)
     instance.appendChild(el)
@@ -147,8 +116,6 @@ describe('bind', () => {
   })
 
   it('can bind multiple elements to the same event', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el1 = document.createElement('div')
     const el2 = document.createElement('div')
     el1.setAttribute('data-action', 'click:bind-test-element#foo')
@@ -163,8 +130,6 @@ describe('bind', () => {
   })
 
   it('binds elements added to elements subtree', async () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     const el1 = document.createElement('div')
     const el2 = document.createElement('div')
     el1.setAttribute('data-action', 'click:bind-test-element#foo')
@@ -187,8 +152,6 @@ describe('bind', () => {
   })
 
   it('can bind elements within the shadowDOM', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     instance.attachShadow({mode: 'open'})
     const el1 = document.createElement('div')
     const el2 = document.createElement('div')
@@ -204,8 +167,6 @@ describe('bind', () => {
   })
 
   it('binds elements added to shadowDOM', async () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
     instance.attachShadow({mode: 'open'})
     const el1 = document.createElement('div')
     const el2 = document.createElement('div')
@@ -225,12 +186,9 @@ describe('bind', () => {
   })
 
   describe('listenForBind', () => {
-    it('re-binds actions that are denoted by HTML that is dynamically injected into the controller', async function () {
-      const instance = document.createElement('bind-test-element')
+    it('re-binds actions that are denoted by HTML that is dynamically injected into the controller', async () => {
       bind(instance)
-      replace(instance, 'foo', fake(instance.foo))
-      root.appendChild(instance)
-      listenForBind(root)
+      listenForBind(instance.ownerDocument)
       const button = document.createElement('button')
       button.setAttribute('data-action', 'click:bind-test-element#foo')
       instance.appendChild(button)
@@ -241,12 +199,8 @@ describe('bind', () => {
       expect(instance.foo).to.have.callCount(1)
     })
 
-    it('will not re-bind actions after unsubscribe() is called', async function () {
-      const instance = document.createElement('bind-test-element')
-      replace(instance, 'foo', fake(instance.foo))
-      root.appendChild(instance)
-      listenForBind(root).unsubscribe()
-      listenForBind(document).unsubscribe()
+    it('will not re-bind actions after unsubscribe() is called', async () => {
+      listenForBind(instance.ownerDocument).unsubscribe()
       const button = document.createElement('button')
       button.setAttribute('data-action', 'click:bind-test-element#foo')
       instance.appendChild(button)
@@ -257,19 +211,15 @@ describe('bind', () => {
       expect(instance.foo).to.have.callCount(0)
     })
 
-    it('will not bind elements that havent already had `bind()` called', async function () {
+    it('will not bind elements that havent already had `bind()` called', async () => {
       customElements.define(
         'bind-test-not-element',
         class BindTestNotController extends HTMLElement {
-          foo() {
-            return 'foo'
-          }
+          foo = fake()
         }
       )
-      const instance = document.createElement('bind-test-not-element')
-      replace(instance, 'foo', fake(instance.foo))
-      root.appendChild(instance)
-      listenForBind(root)
+      instance = await fixture(html`<bind-test-not-element />`)
+      listenForBind(instance.ownerDocument)
       const button = document.createElement('button')
       button.setAttribute('data-action', 'click:bind-test-not-element#foo')
       instance.appendChild(button)
@@ -280,25 +230,22 @@ describe('bind', () => {
       expect(instance.foo).to.have.callCount(0)
     })
 
-    it('will not re-bind elements that just had `bind()` called', async function () {
+    it('will not re-bind elements that just had `bind()` called', async () => {
       customElements.define(
         'bind-test-not-rebind-element',
         class BindTestNotController extends HTMLElement {
+          foo = fake()
           connectedCallback() {
             bind(this)
           }
-          foo() {
-            return 'foo'
-          }
         }
       )
-      const instance = document.createElement('bind-test-not-rebind-element')
-      replace(instance, 'foo', fake(instance.foo))
-      listenForBind(root)
+      instance = await fixture(html`<bind-test-not-rebind-element />`)
+      listenForBind(instance.ownerDocument)
       const button = document.createElement('button')
       button.setAttribute('data-action', 'click:bind-test-not-rebind-element#foo')
       instance.appendChild(button)
-      root.appendChild(instance)
+      replace(instance, 'foo', fake(instance.foo))
       // wait for processQueue
       await Promise.resolve()
       button.click()
@@ -306,12 +253,10 @@ describe('bind', () => {
     })
   })
 
-  it('re-binds actions deeply in the HTML', async function () {
-    const instance = document.createElement('bind-test-element')
+  it('re-binds actions deeply in the HTML', async () => {
+    instance = await fixture(html`<bind-test-element />`)
     bind(instance)
-    replace(instance, 'foo', fake(instance.foo))
-    root.appendChild(instance)
-    listenForBind(root)
+    listenForBind(instance.ownerDocument)
     instance.innerHTML = `
         <div>
           <div>
@@ -326,31 +271,28 @@ describe('bind', () => {
     expect(instance.foo).to.have.callCount(1)
   })
 
-  it('will not fire if the binding attribute is removed', () => {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
-    const el1 = document.createElement('div')
-    el1.setAttribute('data-action', 'click:bind-test-element#foo')
-    instance.appendChild(el1)
+  it('will not fire if the binding attribute is removed', async () => {
+    instance = await fixture(html`<bind-test-element>
+      <div data-action="click:bind-test-element#foo"></div>
+    </bind-test-element>`)
     bind(instance)
     expect(instance.foo).to.have.callCount(0)
-    el1.click()
+    const el = instance.querySelector('div')
+    el.click()
     expect(instance.foo).to.have.callCount(1)
-    el1.setAttribute('data-action', 'click:other-element#foo')
-    el1.click()
+    el.setAttribute('data-action', 'click:other-element#foo')
+    el.click()
     expect(instance.foo).to.have.callCount(1)
   })
 
-  it('will rebind elements if the attribute changes', async function () {
-    const instance = document.createElement('bind-test-element')
-    replace(instance, 'foo', fake(instance.foo))
-    root.appendChild(instance)
-    const button = document.createElement('button')
-    button.setAttribute('data-action', 'submit:bind-test-element#foo')
-    instance.appendChild(button)
+  it('will rebind elements if the attribute changes', async () => {
+    instance = await fixture(html`<bind-test-element>
+      <button data="action" ="submit:bind-test-element#foo"></button>
+    </bind-test-element>`)
     bind(instance)
-    listenForBind(root)
+    listenForBind(instance.ownerDocument)
     await Promise.resolve()
+    const button = instance.querySelector('button')
     button.click()
     expect(instance.foo).to.have.callCount(0)
     button.setAttribute('data-action', 'click:bind-test-element#foo')

--- a/test/bind.ts
+++ b/test/bind.ts
@@ -1,6 +1,6 @@
 import {expect} from '@open-wc/testing'
 import {replace, fake} from 'sinon'
-import {bind, listenForBind} from '../lib/bind.js'
+import {bind, listenForBind} from '../src/bind.js'
 
 describe('bind', () => {
   window.customElements.define(

--- a/test/controller.ts
+++ b/test/controller.ts
@@ -1,7 +1,7 @@
 import {expect} from '@open-wc/testing'
 import {replace, fake} from 'sinon'
-import {controller} from '../lib/controller.js'
-import {attr} from '../lib/attr.js'
+import {controller} from '../src/controller.js'
+import {attr} from '../src/attr.js'
 
 describe('controller', () => {
   let root

--- a/test/controller.ts
+++ b/test/controller.ts
@@ -1,25 +1,15 @@
-import {expect} from '@open-wc/testing'
+import {expect, fixture, html} from '@open-wc/testing'
 import {replace, fake} from 'sinon'
 import {controller} from '../src/controller.js'
 import {attr} from '../src/attr.js'
 
 describe('controller', () => {
-  let root
-
-  beforeEach(() => {
-    root = document.createElement('div')
-    document.body.appendChild(root)
-  })
-
-  afterEach(() => {
-    root.remove()
-  })
+  let instance
 
   it('calls register', async () => {
     @controller
     class ControllerRegisterElement extends HTMLElement {}
-    const instance = document.createElement('controller-register')
-    root.appendChild(instance)
+    instance = await fixture(html`<controller-register />`)
     expect(instance).to.be.instanceof(ControllerRegisterElement)
   })
 
@@ -28,8 +18,7 @@ describe('controller', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class ControllerDataAttrElement extends HTMLElement {}
 
-    const instance = document.createElement('controller-data-attr')
-    root.appendChild(instance)
+    instance = await fixture(html`<controller-data-attr />`)
     expect(instance.hasAttribute('data-catalyst')).to.equal(true)
     expect(instance.getAttribute('data-catalyst')).to.equal('')
   })
@@ -38,9 +27,7 @@ describe('controller', () => {
     @controller
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class ControllerBindOrderElement extends HTMLElement {
-      foo() {
-        return 'foo'
-      }
+      foo = fake()
     }
     @controller
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -49,15 +36,11 @@ describe('controller', () => {
         this.dispatchEvent(new CustomEvent('loaded'))
       }
     }
-
-    const instance = document.createElement('controller-bind-order')
-    replace(instance, 'foo', fake(instance.foo))
-    root.appendChild(instance)
-
-    const sub = document.createElement('controller-bind-order-sub')
-    sub.setAttribute('data-action', 'loaded:controller-bind-order#foo')
-    instance.appendChild(sub)
-
+    instance = await fixture(html`
+      <controller-bind-order>
+        <controller-bind-order-sub data-action="loaded:controller-bind-order#foo" />
+      </controller-bind-order>
+    `)
     expect(instance.foo).to.have.callCount(1)
   })
 
@@ -76,9 +59,8 @@ describe('controller', () => {
         return 'foo'
       }
     }
-    const instance = document.createElement('controller-bind-shadow')
+    instance = await fixture(html`<controller-bind-shadow />`)
     replace(instance, 'foo', fake(instance.foo))
-    root.appendChild(instance)
 
     instance.shadowRoot.querySelector('button').click()
 
@@ -93,14 +75,14 @@ describe('controller', () => {
         return 'foo'
       }
     }
-    const instance = document.createElement('controller-bind-auto-shadow')
-    const template = document.createElement('template')
-    template.setAttribute('data-shadowroot', 'open')
-    // eslint-disable-next-line github/unescaped-html-literal
-    template.innerHTML = '<button data-action="click:controller-bind-auto-shadow#foo"></button>'
-    instance.appendChild(template)
+    instance = await fixture(html`
+      <controller-bind-auto-shadow>
+        <template data-shadowroot="open">
+          <button data-action="click:controller-bind-auto-shadow#foo" />
+        </template>
+      </controller-bind-auto-shadow>
+    `)
     replace(instance, 'foo', fake(instance.foo))
-    root.appendChild(instance)
 
     expect(instance.shadowRoot).to.exist
     expect(instance).to.have.property('shadowRoot').not.equal(null)
@@ -110,7 +92,7 @@ describe('controller', () => {
     expect(instance.foo).to.have.callCount(1)
   })
 
-  it('upgrades child decendants when connected', () => {
+  it('upgrades child decendants when connected', async () => {
     @controller
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     class ChildElementElement extends HTMLElement {}
@@ -123,8 +105,11 @@ describe('controller', () => {
       }
     }
 
-    // eslint-disable-next-line github/unescaped-html-literal
-    root.innerHTML = '<parent-element><child-element></child-element></parent-element>'
+    instance = await fixture(html`
+      <parent-element>
+        <child-element />
+      </parent-element>
+    `)
   })
 
   describe('attrs', () => {
@@ -143,17 +128,17 @@ describe('controller', () => {
       attrValues = []
     })
 
-    it('initializes attrs as attributes in attributeChangedCallback', () => {
-      const el = document.createElement('attribute-test')
-      el.foo = 'bar'
-      el.attributeChangedCallback()
+    it('initializes attrs as attributes in attributeChangedCallback', async () => {
+      instance = await fixture(html`<attribute-test></attribute-test>`)
+      instance.foo = 'bar'
+      instance.attributeChangedCallback()
       expect(attrValues).to.eql(['bar', 'bar'])
     })
 
-    it('initializes attributes as attrs in attributeChangedCallback', () => {
-      const el = document.createElement('attribute-test')
-      el.setAttribute('data-foo', 'bar')
-      el.attributeChangedCallback()
+    it('initializes attributes as attrs in attributeChangedCallback', async () => {
+      instance = await fixture(html`<attribute-test />`)
+      instance.setAttribute('data-foo', 'bar')
+      instance.attributeChangedCallback()
       expect(attrValues).to.eql(['bar', 'bar'])
     })
   })

--- a/test/findtarget.ts
+++ b/test/findtarget.ts
@@ -1,86 +1,65 @@
+import {expect, fixture, html} from '@open-wc/testing'
 import {fake, replace} from 'sinon'
 import {findTarget, findTargets} from '../src/findtarget.js'
 
 describe('findTarget', () => {
   window.customElements.define('find-target-test-element', class extends HTMLElement {})
 
-  let root
-  beforeEach(() => {
-    root = document.createElement('div')
-    document.body.appendChild(root)
-  })
+  let instance
 
-  afterEach(() => {
-    root.remove()
-  })
-
-  it('calls querySelectorAll with the controller name and target name', () => {
-    const instance = document.createElement('find-target-test-element')
+  it('calls querySelectorAll with the controller name and target name', async () => {
+    instance = await fixture(html`<find-target-test-element />`)
     replace(instance, 'querySelectorAll', fake.returns([]))
     findTarget(instance, 'foo')
     expect(instance.querySelectorAll).to.have.been.calledOnceWith('[data-target~="find-target-test-element.foo"]')
   })
 
-  it('returns the first element where closest tag is the controller', () => {
-    const els = [document.createElement('div'), document.createElement('div')]
-    const instance = document.createElement('find-target-test-element')
-    replace(instance, 'querySelectorAll', fake.returns(els))
-    replace(els[0], 'closest', fake.returns(null))
-    replace(els[1], 'closest', fake.returns(instance))
-    const target = findTarget(instance, 'foo')
-    expect(els[0].closest).to.have.been.calledOnceWith('find-target-test-element')
-    expect(els[1].closest).to.have.been.calledOnceWith('find-target-test-element')
-    expect(target).to.equal(els[1])
+  it('returns the first element where closest tag is the controller', async () => {
+    instance = await fixture(html`
+      <find-target-test-element>
+        <find-target-test-element>
+          <div id="1" data-target="find-target-test-element.foo"></div>
+        </find-target-test-element>
+        <div id="2" data-target="find-target-test-element.foo"></div>
+      </find-target-test-element>
+    `)
+    expect(findTarget(instance, 'foo')).to.have.attribute('id', '2')
   })
 
-  it('returns the first element that has the exact target name', () => {
-    const instance = document.createElement('find-target-test-element')
-
-    const notExactMatch = document.createElement('div')
-    notExactMatch.setAttribute('data-target', 'find-target-test-element.foobar')
-    const exactMatch = document.createElement('div')
-    exactMatch.setAttribute('data-target', 'find-target-test-element.foo')
-
-    instance.appendChild(notExactMatch)
-    instance.appendChild(exactMatch)
-
-    const foundElement = findTarget(instance, 'foo')
-
-    expect(foundElement).to.equal(exactMatch)
+  it('returns the first element that has the exact target name', async () => {
+    instance = await fixture(html`
+      <find-target-test-element>
+        <div id="1" data-target="find-target-test-element.foobar"></div>
+        <div id="2" data-target="find-target-test-element.foo"></div>
+      </find-target-test-element>
+    `)
+    expect(findTarget(instance, 'foo')).to.have.attribute('id', '2')
   })
 
-  it('returns targets when there are mutliple target values', () => {
-    const instance = document.createElement('find-target-test-element')
-
-    const el = document.createElement('div')
-    el.setAttribute('data-target', 'find-target-test-element.barfoo find-target-test-element.foobar')
-
-    instance.appendChild(el)
-
-    const foundElement1 = findTarget(instance, 'foobar')
-    const foundElement2 = findTarget(instance, 'barfoo')
-
-    expect(foundElement1).to.equal(el)
-    expect(foundElement2).to.equal(el)
+  it('returns targets when there are mutliple target values', async () => {
+    instance = await fixture(html`
+      <find-target-test-element>
+        <div id="1" data-target="find-target-test-element.barfoo find-target-test-element.foobar"></div>
+        <div id="2" data-target="find-target-test-element.foo"></div>
+      </find-target-test-element>
+    `)
+    expect(findTarget(instance, 'foo')).to.have.attribute('id', '2')
+    expect(findTarget(instance, 'barfoo')).to.have.attribute('id', '1')
+    expect(findTarget(instance, 'barfoo')).to.equal(findTarget(instance, 'foobar'))
   })
 
-  it('returns targets when there are mutliple target values with different controllers', () => {
-    const instance = document.createElement('find-target-test-element')
-
-    const el = document.createElement('div')
-    el.setAttribute('data-target', 'other-controller.barfoo find-target-test-element.foobar')
-
-    instance.appendChild(el)
-
-    const foundElement1 = findTarget(instance, 'foobar')
-    const foundElement2 = findTarget(instance, 'barfoo')
-
-    expect(foundElement1).to.equal(el)
-    expect(foundElement2).to.equal(undefined)
+  it('returns targets when there are mutliple target values with different controllers', async () => {
+    instance = await fixture(html`
+      <find-target-test-element>
+        <div id="1" data-target="other-controller.barfoo find-target-test-element.foobar"></div>
+      </find-target-test-element>
+    `)
+    expect(findTarget(instance, 'foobar')).to.have.attribute('id', '1')
+    expect(findTarget(instance, 'barfoo')).to.equal(undefined)
   })
 
-  it('returns targets from the shadowRoot, if available', () => {
-    const instance = document.createElement('find-target-test-element')
+  it('returns targets from the shadowRoot, if available', async () => {
+    instance = await fixture(html`<find-target-test-element></find-target-test-element>`)
     instance.attachShadow({mode: 'open'})
     const el = document.createElement('div')
     el.setAttribute('data-target', 'find-target-test-element.foobar')
@@ -90,47 +69,49 @@ describe('findTarget', () => {
     expect(findTarget(instance, 'foobar')).to.equal(el)
   })
 
-  it('prioritises shadowRoot targets over others', () => {
-    const instance = document.createElement('find-target-test-element')
+  it('prioritises shadowRoot targets over others', async () => {
+    instance = await fixture(html` <find-target-test-element>
+      <div data-target="find-target-test-element.foobar"></div>
+    </find-target-test-element>`)
     instance.attachShadow({mode: 'open'})
     const shadowEl = document.createElement('div')
     shadowEl.setAttribute('data-target', 'find-target-test-element.foobar')
-    const lightEl = document.createElement('div')
-    lightEl.setAttribute('data-target', 'find-target-test-element.foobar')
-
     instance.shadowRoot.appendChild(shadowEl)
-    instance.appendChild(lightEl)
-
     expect(findTarget(instance, 'foobar')).to.equal(shadowEl)
   })
 })
 
 describe('findTargets', () => {
-  it('calls querySelectorAll with the controller name and target name', () => {
-    const instance = document.createElement('find-target-test-element')
-    const els = [document.createElement('div'), document.createElement('div'), document.createElement('div')]
-    instance.append(...els)
+  let instance
 
-    els[0].setAttribute('data-targets', 'find-target-test-element.foo')
-    els[1].setAttribute('data-targets', 'find-target-test-element.foo')
-
-    expect(findTargets(instance, 'foo')).to.eql([els[0], els[1]])
+  it('calls querySelectorAll with the controller name and target name', async () => {
+    instance = await fixture(html`<find-target-test-element>
+      <div id="1" data-targets="find-target-test-element.foo"></div>
+      <div id="2" data-targets="find-target-test-element.foo"></div>
+      <div id="3" data-targets="find-target-test-element.bar"></div>
+    </find-target-test-element>`)
+    const els = findTargets(instance, 'foo')
+    expect(els).to.have.lengthOf(2)
+    expect(els[0]).to.have.attribute('id', '1')
+    expect(els[1]).to.have.attribute('id', '2')
   })
 
-  it('returns all elements where closest tag is the controller', () => {
-    const instance = document.createElement('find-target-test-element')
-    const els = [document.createElement('div'), document.createElement('div'), document.createElement('div')]
-    for (const el of els) el.setAttribute('data-targets', 'find-target-test-element.foo')
-    const nested = document.createElement('find-target-test-element')
-
-    nested.append(els[1])
-    instance.append(els[0], nested, els[2])
-
-    expect(findTargets(instance, 'foo')).to.eql([els[0], els[2]])
+  it('returns all elements where closest tag is the controller', async () => {
+    instance = await fixture(html`<find-target-test-element>
+      <div id="1" data-targets="find-target-test-element.foo"></div>
+      <div id="2" data-targets="find-target-test-element.foo"></div>
+      <find-target-test-element>
+        <div id="3" data-targets="find-target-test-element.foo"></div>
+      </find-target-test-element>
+    </find-target-test-element>`)
+    const els = findTargets(instance, 'foo')
+    expect(els).to.have.lengthOf(2)
+    expect(els[0]).to.have.attribute('id', '1')
+    expect(els[1]).to.have.attribute('id', '2')
   })
 
-  it('returns all elements inside a shadow root', () => {
-    const instance = document.createElement('find-target-test-element')
+  it('returns all elements inside a shadow root', async () => {
+    instance = await fixture(html`<find-target-test-element></find-target-test-element>`)
     instance.attachShadow({mode: 'open'})
     const els = [document.createElement('div'), document.createElement('div'), document.createElement('div')]
     for (const el of els) el.setAttribute('data-targets', 'find-target-test-element.foo')

--- a/test/findtarget.ts
+++ b/test/findtarget.ts
@@ -1,6 +1,5 @@
 import {fake, replace} from 'sinon'
-import {expect} from '@open-wc/testing'
-import {findTarget, findTargets} from '../lib/findtarget.js'
+import {findTarget, findTargets} from '../src/findtarget.js'
 
 describe('findTarget', () => {
   window.customElements.define('find-target-test-element', class extends HTMLElement {})

--- a/test/register.ts
+++ b/test/register.ts
@@ -1,5 +1,5 @@
 import {expect} from '@open-wc/testing'
-import {register} from '../lib/register.js'
+import {register} from '../src/register.js'
 
 describe('register', () => {
   it('registers the class as a custom element, normalising the class name', () => {


### PR DESCRIPTION
This makes the tests a little easier to read as they use html fixtures now. It also makes sure that `npm test` runs just the tests, rather than the lint/size step before hand