### PR TITLE
Allow custom element name to be passed to @controller

### DIFF
--- a/docs/_guide/you-will-need.md
+++ b/docs/_guide/you-will-need.md
@@ -64,20 +64,18 @@ When using SWC you can use the `keep_classnames` option just like Terser. As SWC
 
 #### Other alternatives
 
-If your tool chain does not support opting out of minification, or if you would prefer to keep name minification on, you can instead selectively re-assign the `name` field to Catalyst controllers:
+If your tool chain does not support opting out of minification, or if you would prefer to keep name minification on, you can manually pass the element name as a parameter to the `@controller` decorator.  Note, the name passed in will not be modified in any way when registering the custom element, and should be `dash-cased`.
 
 ```ts
-@controller
+@controller('user-list')
 class UserList extends HTMLElement {
-  static name = 'UserList'
 }
 ```
 
 TypeScript decorators only support _class declarations_ which means you will still need to keep the class name between `class` and `extends`. For example the following will be a SyntaxError:
 
 ```ts
-@controller
+@controller('user-list')
 class extends HTMLElement {
-  static name = 'UserList'
 }
 ```

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -6,6 +6,13 @@ import type {CustomElement} from './custom-element.js'
  * registry, as well as ensuring `bind(this)` is called on `connectedCallback`,
  * wrapping the classes `connectedCallback` method if needed.
  */
-export function controller(classObject: CustomElement): void {
-  new CatalystDelegate(classObject)
+export function controller(classObjectOrName: CustomElement | string) {
+  if (typeof classObjectOrName === 'string') {
+    const name = classObjectOrName
+    return (classObject: CustomElement) => {
+      new CatalystDelegate(classObject, name)
+    }
+  }
+
+  new CatalystDelegate(classObjectOrName)
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -7,7 +7,7 @@ import type {CustomElement} from './custom-element.js'
 const symbol = Symbol.for('catalyst')
 
 export class CatalystDelegate {
-  constructor(classObject: CustomElement) {
+  constructor(classObject: CustomElement, elementName?: string) {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const delegate = this
 
@@ -43,7 +43,7 @@ export class CatalystDelegate {
     })
 
     defineObservedAttributes(classObject)
-    register(classObject)
+    register(classObject, elementName)
   }
 
   observedAttributes(instance: HTMLElement, observedAttributes: string[]) {

--- a/src/register.ts
+++ b/src/register.ts
@@ -8,8 +8,8 @@ import {dasherize} from './dasherize.js'
  *
  * Example: HelloController => hello-controller
  */
-export function register(classObject: CustomElement): CustomElement {
-  const name = dasherize(classObject.name).replace(/-element$/, '')
+export function register(classObject: CustomElement, elementName?: string): CustomElement {
+  const name = elementName || dasherize(classObject.name).replace(/-element$/, '')
 
   try {
     window.customElements.define(name, classObject)

--- a/test/controller.ts
+++ b/test/controller.ts
@@ -142,4 +142,11 @@ describe('controller', () => {
       expect(attrValues).to.eql(['bar', 'bar'])
     })
   })
+
+  it('allows element name to be overridden', async () => {
+    @controller('other-name')
+    class CustomRegisterElement extends HTMLElement {}
+    instance = await fixture(html`<other-name />`)
+    expect(instance).to.be.instanceof(CustomRegisterElement)
+  })
 })


### PR DESCRIPTION
Relates to #98 

Within GitHub, we have switched between build tools and minifiers a few times recently.  The requirement for catalyst to keep the class name has been a continual point of friction during these transitions, and currently adds bloat to our production bundles because `esbuild` only has the simple `keepNames` (which keeps function names as well).  

Rather than fight with the minifier to keep the class names that we need, I propose we add the ability to pass an optional string to `@controller` which will be used as the element name.

From a usability perspective, this doesn't need to have an impact on daily use of catalyst components.  We can easily write a plugin for webpack (or any other build tool) that does a simpler regex replace and inserts the string at build time.

Note: I did try the `static name = 'UserList'` approach, which caused an error in the browser because we were trying to overwrite the readonly name property.  