### PR TITLE
add initializer to marks

### DIFF
--- a/src/get-property-descriptor.ts
+++ b/src/get-property-descriptor.ts
@@ -1,0 +1,7 @@
+export const getPropertyDescriptor = (instance: unknown, key: PropertyKey): PropertyDescriptor | undefined => {
+  while (instance) {
+    const descriptor = Object.getOwnPropertyDescriptor(instance, key)
+    if (descriptor) return descriptor
+    instance = Object.getPrototypeOf(instance)
+  }
+}

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -1,39 +1,67 @@
+import {getPropertyDescriptor} from './get-property-descriptor.js'
+
 type PropertyType = 'field' | 'getter' | 'setter' | 'method'
-interface PropertyDecorator {
+export interface PropertyDecorator {
   (proto: object, key: PropertyKey, descriptor?: PropertyDescriptor): void
   readonly static: unique symbol
 }
-type GetMarks = (instance: object) => Set<PropertyKey>
-export function createMark(validate: (key: PropertyKey, type: PropertyType) => void): [PropertyDecorator, GetMarks] {
+type GetMarks<T> = (instance: T) => Set<PropertyKey>
+type InitializeMarks<T> = (instance: T) => void
+
+type Context = {
+  kind: PropertyType
+  name: PropertyKey
+  access: PropertyDescriptor
+}
+
+const getType = (descriptor?: PropertyDescriptor): PropertyType => {
+  if (descriptor) {
+    if (typeof descriptor.value === 'function') return 'method'
+    if (typeof descriptor.get === 'function') return 'getter'
+    if (typeof descriptor.set === 'function') return 'setter'
+  }
+  return 'field'
+}
+
+export function createMark<T extends object>(
+  validate: (context: {name: PropertyKey; kind: PropertyType}) => void,
+  initialize: (instance: T, context: Context) => PropertyDescriptor | void
+): [PropertyDecorator, GetMarks<T>, InitializeMarks<T>] {
   const marks = new WeakMap<object, Set<PropertyKey>>()
-  function get(proto: object): Set<PropertyKey> {
+  const get = (proto: object): Set<PropertyKey> => {
     if (!marks.has(proto)) {
       const parent = Object.getPrototypeOf(proto)
-      marks.set(proto, new Set(marks.get(parent) || []))
+      marks.set(proto, new Set(parent ? get(parent) || [] : []))
     }
     return marks.get(proto)!
   }
-  const marker = (proto: object, key: PropertyKey, descriptor?: PropertyDescriptor): void => {
-    if (get(proto).has(key)) return
-    let type: PropertyType = 'field'
-    if (descriptor) {
-      if (typeof descriptor.value === 'function') type = 'method'
-      if (typeof descriptor.get === 'function') type = 'getter'
-      if (typeof descriptor.set === 'function') type = 'setter'
-    }
-    validate(key, type)
-    get(proto).add(key)
+  const marker = (proto: object, name: PropertyKey, descriptor?: PropertyDescriptor): void => {
+    if (get(proto).has(name)) return
+    validate({name, kind: getType(descriptor)})
+    get(proto).add(name)
   }
   marker.static = Symbol()
-
+  const getMarks = (instance: T): Set<PropertyKey> => {
+    const proto = Object.getPrototypeOf(instance)
+    for (const key of proto.constructor[marker.static] || []) {
+      marker(proto, key, Object.getOwnPropertyDescriptor(proto, key))
+    }
+    return new Set(get(proto))
+  }
   return [
     marker as PropertyDecorator,
-    (instance: object): Set<PropertyKey> => {
-      const proto = Object.getPrototypeOf(instance)
-      for (const key of proto.constructor[marker.static] || []) {
-        marker(proto, key, Object.getOwnPropertyDescriptor(proto, key))
+    getMarks,
+    (instance: T): void => {
+      for (const name of getMarks(instance)) {
+        const access: PropertyDescriptor = getPropertyDescriptor(instance, name) || {
+          value: void 0,
+          configurable: true,
+          writable: true,
+          enumerable: true
+        }
+        const newDescriptor = initialize(instance, {name, kind: getType(access), access}) || access
+        Object.defineProperty(instance, name, newDescriptor)
       }
-      return new Set(get(proto))
     }
   ]
 }

--- a/test/mark.ts
+++ b/test/mark.ts
@@ -207,7 +207,6 @@ describe('createMark', () => {
     const fooBar = new FooBar()
     getMarks(fooBar)
     expect(initialize).to.have.callCount(0)
-    console.log(...getMarks(fooBar))
     initializeMarks(fooBar)
     const accessFor = (field: PropertyKey) => Object.getOwnPropertyDescriptor(FooBar.prototype, field)
     expect(initialize).to.be.calledWithExactly(fooBar, {


### PR DESCRIPTION
This adds initializers to marks, which allows for abilities to more easily construct behaviours based on marked fields.

This _would_ be a breaking change if we exported marks or otherwise had already released it, but since we haven't this can go into main and be fine!

This is more ground work for v2.