### PR TITLE
Fix typo in providable code sample

### DIFF
--- a/docs/_guide/providable.md
+++ b/docs/_guide/providable.md
@@ -49,7 +49,7 @@ class UserRow extends HTMLElement {
     // This will provide `userId` as '123' to any nested children that request it.
     @provide userId = '123'
     // This will provide `userName` as 'Alex' to any nested children that request it.
-    @provide userId = 'Alex'
+    @provide userName = 'Alex'
 }
 ```
 


### PR DESCRIPTION
This code sample uses `userId` for both properties but based on context it seems like the second one is intended to be `userName`.