### PR TITLE
Fix providable bugs

### DIFF
--- a/src/providable.ts
+++ b/src/providable.ts
@@ -86,12 +86,14 @@ export const providable = createAbility(
       constructor(...args: any[]) {
         super(...args)
         initProvide(this)
-        if (getProvide(this).size) {
+        const provides = getProvide(this)
+        if (provides.size) {
           if (!contexts.has(this)) contexts.set(this, new Map())
           const instanceContexts = contexts.get(this)!
           this.addEventListener('context-request', event => {
             if (!isContextEvent(event)) return
             const name = event.context.name
+            if (!provides.has(name)) return
             const value = this[name]
             const dispose = () => instanceContexts.get(name)?.delete(callback)
             const eventCallback = event.callback
@@ -100,6 +102,7 @@ export const providable = createAbility(
               if (!instanceContexts.has(name)) instanceContexts.set(name, new Set())
               instanceContexts.get(name)!.add(callback)
             }
+            event.stopPropagation()
             callback(value)
           })
         }


### PR DESCRIPTION
A couple of bugs that came through extended testing of `providable`.

> fix bug in providable where it should only dispose of older disposers
>
> This was causing values to be discarded after the first change which is
a mistake. The disposer should be called only if it recieves a new one
(meaning a different provider has entered the ring).

> fix nested & partial providers
>
>If a provider cannot supply a value it should not, and so we need to
check if it has the available `@provide` name.
>
>If a provider _can_ supply a value it should stopPropagation to avoid
letting other providers assign and callback.