### PR TITLE
ability subclasses should retain original class name

### DIFF
--- a/src/ability.ts
+++ b/src/ability.ts
@@ -9,6 +9,7 @@ export const createAbility = <TExtend, TClass extends CustomElementClass>(
     const markers = abilityMarkers.get(Class)
     if (markers?.has(decorate as Decorator)) return Class as unknown as TExtend
     const NewClass = decorate(Class) as TExtend
+    Object.defineProperty(NewClass, 'name', {value: Class.name})
     const newMarkers = new Set(markers)
     newMarkers.add(decorate as Decorator)
     abilityMarkers.set(NewClass as unknown as CustomElementClass, newMarkers)

--- a/src/controllable.ts
+++ b/src/controllable.ts
@@ -20,12 +20,6 @@ const internalsCalled = new WeakSet()
 export const controllable = createAbility(
   <T extends CustomElementClass>(Class: T): T & ControllableClass =>
     class extends Class {
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore TypeScript doesn't like assigning static name
-      static get name() {
-        return Class.name
-      }
-
       // TS mandates Constructors that get mixins have `...args: any[]`
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       constructor(...args: any[]) {

--- a/test/ability.ts
+++ b/test/ability.ts
@@ -67,6 +67,13 @@ describe('ability', () => {
     expect(DElement).to.have.property('prototype').instanceof(Element)
   })
 
+  it('retains original class name', () => {
+    const DElement = fakeable(Element)
+    const D2Element = otherfakeable(Element)
+    expect(DElement).to.have.property('name', 'Element')
+    expect(D2Element).to.have.property('name', 'Element')
+  })
+
   it('can be used in decorator position', async () => {
     @fakeable
     class DElement extends HTMLElement {}


### PR DESCRIPTION
This fixes a bug where ability subclasses end up being anonymous, which makes them impossible to register. Ability classes should retain the original class name.