### PR TITLE
ensure marks default to configurable+enumerable

### DIFF
--- a/src/mark.ts
+++ b/src/mark.ts
@@ -60,7 +60,7 @@ export function createMark<T extends object>(
           enumerable: true
         }
         const newDescriptor = initialize(instance, {name, kind: getType(access), access}) || access
-        Object.defineProperty(instance, name, newDescriptor)
+        Object.defineProperty(instance, name, Object.assign({configurable: true, enumerable: true}, newDescriptor))
       }
     }
   ]

--- a/test/mark.ts
+++ b/test/mark.ts
@@ -231,4 +231,26 @@ describe('createMark', () => {
     expect(initialize).to.be.calledWithExactly(fooBar, {name: 'grault', kind: 'method', access: accessFor('grault')})
     expect(initialize).to.be.calledWithExactly(fooBar, {name: sym, kind: 'method', access: accessFor(sym)})
   })
+
+  it('can apply multiple different marks to the same property', () => {
+    const [mark1, getMarks1, initializeMarks1] = createMark(
+      fake(),
+      fake(() => ({get: fake(), set: fake()}))
+    )
+    const [mark2, getMarks2, initializeMarks2] = createMark(
+      fake(),
+      fake(() => ({get: fake(), set: fake()}))
+    )
+    class FooBar {
+      @mark1 @mark2 foo: unknown
+      @mark2 @mark1 bar = 'hi'
+      constructor() {
+        initializeMarks1(this)
+        initializeMarks2(this)
+      }
+    }
+    const fooBar = new FooBar()
+    expect(Array.from(getMarks1(fooBar))).to.eql(['foo', 'bar'])
+    expect(Array.from(getMarks2(fooBar))).to.eql(['foo', 'bar'])
+  })
 })


### PR DESCRIPTION
This fixes a bug where multiple marks used in conjunction throw an error, because the properties defined by marks default to non-configurable. They should default to `enumerable` and `configurable` by default.