### PR TITLE
rename tag-observer exports

### DIFF
--- a/src/tag-observer.ts
+++ b/src/tag-observer.ts
@@ -11,7 +11,7 @@ function closestShadowPiercing(el: Element, tagName: string): Element | null {
   return closest
 }
 
-export const tags = (el: Element, tag: string, parse: Parse) =>
+export const parseElementTags = (el: Element, tag: string, parse: Parse) =>
   (el.getAttribute(tag) || '')
     .trim()
     .split(/\s+/g)
@@ -26,34 +26,34 @@ const observer = new MutationObserver((mutations: MutationRecord[]) => {
 
       if (el instanceof Element && registry.has(tag)) {
         const [parse, found] = registry.get(tag)!
-        for (const [tagName, ...meta] of tags(el, tag, parse)) {
+        for (const [tagName, ...meta] of parseElementTags(el, tag, parse)) {
           const controller = closestShadowPiercing(el, tagName)
           if (controller) found(el, controller, tag, ...meta)
         }
       }
     } else if (mutation.addedNodes.length) {
       for (const node of mutation.addedNodes) {
-        if (node instanceof Element) add(node)
+        if (node instanceof Element) observeElementForTags(node)
       }
     }
   }
 })
 
-export const register = (tag: string, parse: Parse, found: Found) => {
+export const registerTag = (tag: string, parse: Parse, found: Found) => {
   if (registry.has(tag)) throw new Error('duplicate tag')
   registry.set(tag, [parse, found])
 }
 
-export const add = (root: Element | ShadowRoot) => {
+export const observeElementForTags = (root: Element | ShadowRoot) => {
   for (const [tag, [parse, found]] of registry) {
     for (const el of root.querySelectorAll(`[${tag}]`)) {
-      for (const [tagName, ...meta] of tags(el, tag, parse)) {
+      for (const [tagName, ...meta] of parseElementTags(el, tag, parse)) {
         const controller = closestShadowPiercing(el, tagName)
         if (controller) found(el, controller, tag, ...meta)
       }
     }
     if (root instanceof Element && root.hasAttribute(tag)) {
-      for (const [tagName, ...meta] of tags(root, tag, parse)) {
+      for (const [tagName, ...meta] of parseElementTags(root, tag, parse)) {
         const controller = closestShadowPiercing(root, tagName)
         if (controller) found(root, controller, tag, ...meta)
       }

--- a/test/tag-observer.ts
+++ b/test/tag-observer.ts
@@ -1,6 +1,6 @@
 import {expect, fixture, html} from '@open-wc/testing'
 import {fake, match} from 'sinon'
-import {register, add} from '../src/tag-observer.js'
+import {registerTag, observeElementForTags} from '../src/tag-observer.js'
 
 describe('tag observer', () => {
   let instance: HTMLElement
@@ -11,20 +11,20 @@ describe('tag observer', () => {
   })
 
   it('can register new tag observers', () => {
-    register('foo', fake(), fake())
+    registerTag('foo', fake(), fake())
   })
 
   it('throws an error when registering a duplicate', () => {
-    register('duplicate', fake(), fake())
-    expect(() => register('duplicate', fake(), fake())).to.throw()
+    registerTag('duplicate', fake(), fake())
+    expect(() => registerTag('duplicate', fake(), fake())).to.throw()
   })
 
   describe('registered behaviour', () => {
     const testParse = fake(v => v.split('.'))
     const testFound = fake()
-    register('data-tagtest', testParse, testFound)
+    registerTag('data-tagtest', testParse, testFound)
     beforeEach(() => {
-      add(instance)
+      observeElementForTags(instance)
     })
 
     it('uses parse to extract tagged element values', () => {
@@ -43,7 +43,7 @@ describe('tag observer', () => {
     it('calls found if added to a node that has tags on itself', () => {
       const div = document.createElement('div')
       div.setAttribute('data-tagtest', 'div.j.k.l')
-      add(div)
+      observeElementForTags(div)
       expect(testParse).to.be.calledWithExactly('div.j.k.l')
       expect(testFound).to.be.calledWithExactly(div, div, 'data-tagtest', 'j', 'k', 'l')
     })
@@ -54,7 +54,7 @@ describe('tag observer', () => {
       const span = document.createElement('span')
       span.setAttribute('data-tagtest', 'div.m.n.o')
       shadow.append(span)
-      add(span)
+      observeElementForTags(span)
       expect(testParse).to.be.calledWithExactly('div.m.n.o')
       expect(testFound).to.be.calledWithExactly(span, div, 'data-tagtest', 'm', 'n', 'o')
     })
@@ -65,7 +65,7 @@ describe('tag observer', () => {
       const span = document.createElement('span')
       span.setAttribute('data-tagtest', 'div.p.q.r')
       shadow.append(span)
-      add(shadow)
+      observeElementForTags(shadow)
       expect(testParse).to.be.calledWithExactly('div.p.q.r')
       expect(testFound).to.be.calledWithExactly(span, div, 'data-tagtest', 'p', 'q', 'r')
     })


### PR DESCRIPTION
When discussing API ergonomics with @koddsson he pointed out that the named exports in `tag-observer` weren't very clear as to their intention. This renames those APIs to be much clearer.

This isn't a breaking change because none of this is exported, but will be in 2.0.