### PR TITLE
simplify abilities docs - link to expanded Create Ability docs

### DIFF
--- a/docs/_guide/abilities.md
+++ b/docs/_guide/abilities.md
@@ -4,7 +4,7 @@ subtitle: Abilities
 hidden: true
 ---
 
-Under the hood Catalyst's controller decorator is comprised of a handful of separate "abilities". Each of these abilities is created with the `createAbility` function. An "ability" is essentially a mixin or perhaps "higher order class". An ability takes a class and returns an extended class that adds additional behaviours. Importantly abilities are idempotent, meaning applying an ability to a class multiple times is safe and the ability is only applied once. By convention all abilities exported by Catalyst are suffixed with `able` which we think is a nice way to denote that something is an ability and should be used as such. Catalyst also exposes all of the tooling to create your own abilities in your own code which we'd encourage if you find yourself repeating patterns within components (if you think you've got a really useful ability, we'd love for you to contribute it)!
+Under the hood Catalyst's controller decorator is comprised of a handful of separate "abilities". An "ability" is essentially a mixin or perhaps "higher order class". An ability takes a class and returns an extended class that adds additional behaviours. By convention all abilities exported by Catalyst are suffixed with `able` which we think is a nice way to denote that something is an ability and should be used as such.
 
 ### Using Abilities
 
@@ -47,4 +47,6 @@ The `@controller` decorator also applies the `@register` decorator which automat
 
 The following abilities are shipped with Catalyst but require manually applying as they aren't considered critical functionality:
 
- - `providable` - the ability to define `provider` and `consumer` properties. See [Providable]({{ side.baseurl }}/guide/providable) for more.
+ - `providable` - the ability to define `provider` and `consumer` properties. See [Providable]({{ site.baseurl }}/guide/providable) for more.
+
+In addition to the provided abilities, Catalyst provides all of the tooling to create your own custom abilities. Take a look at the [Create Ability]({{ site.baseurl }}/guide/create-ability) documentation for more!


### PR DESCRIPTION
This PR simplifies some of the documentation around abilities - instead calling out the Create Ability docs.