### PR TITLE
remove hidden true from v2 pages

### DIFF
--- a/docs/_guide/abilities.md
+++ b/docs/_guide/abilities.md
@@ -1,7 +1,6 @@
 ---
 chapter: 14
 subtitle: Abilities
-hidden: true
 ---
 
 Under the hood Catalyst's controller decorator is comprised of a handful of separate "abilities". Each of these abilities is created with the `createAbility` function. An "ability" is essentially a mixin or perhaps "higher order class". An ability takes a class and returns an extended class that adds additional behaviours. Importantly abilities are idempotent, meaning applying an ability to a class multiple times is safe and the ability is only applied once. By convention all abilities exported by Catalyst are suffixed with `able` which we think is a nice way to denote that something is an ability and should be used as such. Catalyst also exposes all of the tooling to create your own abilities in your own code which we'd encourage if you find yourself repeating patterns within components (if you think you've got a really useful ability, we'd love for you to contribute it)!

--- a/docs/_guide/create-ability.md
+++ b/docs/_guide/create-ability.md
@@ -1,7 +1,6 @@
 ---
 chapter: 16 
 subtitle: Create your own abilities
-hidden: true
 ---
 
 Catalyst provides the functionality to create your own abilities, with a few helper methods and a `controllable` base-level ability. These are explained in detail below, but for a quick summary they are:

--- a/docs/_guide/providable.md
+++ b/docs/_guide/providable.md
@@ -1,7 +1,6 @@
 ---
 chapter: 15
 subtitle: The Provider pattern
-hidden: true
 ---
 
 The [Provider pattern](https://www.patterns.dev/posts/provider-pattern/) allows for deeply nested children to ask ancestors for values. This can be useful for decoupling state inside a component, centralising it higher up in the DOM heirarchy. A top level container component might store values, and many children can consume those values, without having logic duplicated across the app. It's quite an abstract pattern so is better explained with examples...


### PR DESCRIPTION
These pages do not need to be hidden for v2, just `main`.