### PR TITLE
allow for customising prefix of @attr names

### DIFF
--- a/src/custom-element.ts
+++ b/src/custom-element.ts
@@ -16,4 +16,6 @@ export interface CustomElementClass {
   observedAttributes?: string[]
   disabledFeatures?: string[]
   formAssociated?: boolean
+
+  attrPrefix?: string
 }

--- a/test/attr.ts
+++ b/test/attr.ts
@@ -156,4 +156,25 @@ describe('Attr', () => {
       expect(instance.getAttributeNames()).to.include('data-clip-x')
     })
   })
+
+  describe('prefix', () => {
+    @controller
+    class PrefixAttrTest extends HTMLElement {
+      static attrPrefix = 'foo-'
+      @attr fooBarBazBing = 'a'
+      @attr URLBar = 'b'
+      @attr ClipX = 'c'
+    }
+
+    let instance: PrefixAttrTest
+    beforeEach(async () => {
+      instance = await fixture(html`<prefix-attr-test />`)
+    })
+
+    it('respects custom attrPrefix static member', async () => {
+      expect(instance.getAttributeNames()).to.include('foo-foo-bar-baz-bing')
+      expect(instance.getAttributeNames()).to.include('foo-url-bar')
+      expect(instance.getAttributeNames()).to.include('foo-clip-x')
+    })
+  })
 })


### PR DESCRIPTION
This is a feature we're intending to add _just_ for the 1.x branch of Catalyst, in order to ease the transition into Catalyst 2.0. 

This change will respect a `attrPrefix` static member on a class, and use that to derive the prefix of all `@attr`s in the class. This will default to `data-` meaning this is a non-breaking change, but for classes that wish to - they can add, for example, `static attrPrefix = ''` to remove the `data-` prefix. This allows us to transition controllers one-by-one while using Catalyst 1.x, which will make the transition to Catalyst 2.x much more straightforward.

This property will _not_ be in Catalyst 2.0, as there is no need for it, as attrs are not prefixed with anything in Catalyst 2.0.