### PR TITLE
wrong urls for prev and next links

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
       faraday (> 0.8, < 2.0)
 
 PLATFORMS
+  universal-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -98,7 +98,6 @@ GEM
       faraday (> 0.8, < 2.0)
 
 PLATFORMS
-  universal-darwin-21
   x86_64-linux
 
 DEPENDENCIES

--- a/docs/_layouts/guide.html
+++ b/docs/_layouts/guide.html
@@ -27,12 +27,12 @@ layout: default
       <div class="mt-4">
         <nav class="prev-next-links" aria-label="Pagination">
           {% if prev %}
-          <a class="prev-next-links__button" rel="previous" href="{{prev.url}}" aria-label="Previous Page">
+          <a class="prev-next-links__button" rel="previous" href="{{ site.baseurl }}{{prev.url}}" aria-label="Previous Page">
             <div class="f6 text-uppercase">Previous</div>
             {{prev.title}}
           </a>
           {% endif %} {% if next %}
-          <a class="prev-next-links__button" rel="next" href="{{next.url}}" aria-label="Next Page">
+          <a class="prev-next-links__button" rel="next" href="{{ site.baseurl }}{{next.url}}" aria-label="Next Page">
             <div class="f6 text-uppercase">Next</div>
             {{next.title}}
           </a>


### PR DESCRIPTION
I made a mistake on the previous and next links button PR by forgetting the base url which works in dev mode but not on GitHub Pages. It should be fixed now as I copied from the links on the sidebar (and it still works in local). First OSS bug :)