### PR TITLE
add provideAsync

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     {
       "path": "lib/abilities.js",
       "import": "{providable}",
-      "limit": "1.1kb"
+      "limit": "1.5kb"
     }
   ]
 }

--- a/test/lazy-define.ts
+++ b/test/lazy-define.ts
@@ -2,6 +2,8 @@ import {expect, fixture, html} from '@open-wc/testing'
 import {spy} from 'sinon'
 import {lazyDefine} from '../src/lazy-define.js'
 
+const animationFrame = () => new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+
 describe('lazyDefine', () => {
   describe('ready strategy', () => {
     it('calls define for a lazy component', async () => {
@@ -9,7 +11,7 @@ describe('lazyDefine', () => {
       lazyDefine('scan-document-test', onDefine)
       await fixture(html`<scan-document-test></scan-document-test>`)
 
-      await new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+      await animationFrame()
 
       expect(onDefine).to.be.callCount(1)
     })
@@ -19,7 +21,7 @@ describe('lazyDefine', () => {
       await fixture(html`<later-defined-element-test></later-defined-element-test>`)
       lazyDefine('later-defined-element-test', onDefine)
 
-      await new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+      await animationFrame()
 
       expect(onDefine).to.be.callCount(1)
     })
@@ -39,7 +41,7 @@ describe('lazyDefine', () => {
         <twice-defined-element></twice-defined-element>
       `)
 
-      await new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+      await animationFrame()
 
       expect(onDefine).to.be.callCount(2)
     })
@@ -51,12 +53,12 @@ describe('lazyDefine', () => {
       lazyDefine('scan-document-test', onDefine)
       await fixture(html`<scan-document-test data-load-on="firstInteraction"></scan-document-test>`)
 
-      await new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+      await animationFrame()
       expect(onDefine).to.be.callCount(0)
 
       document.dispatchEvent(new Event('mousedown'))
 
-      await new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+      await animationFrame()
       expect(onDefine).to.be.callCount(1)
     })
   })
@@ -68,12 +70,12 @@ describe('lazyDefine', () => {
         html`<div style="height: calc(100vh + 256px)"></div>
           <scan-document-test data-load-on="visible"></scan-document-test>`
       )
-      await new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+      await animationFrame()
       expect(onDefine).to.be.callCount(0)
 
       document.documentElement.scrollTo({top: 10})
 
-      await new Promise<unknown>(resolve => requestAnimationFrame(resolve))
+      await animationFrame()
       expect(onDefine).to.be.callCount(1)
     })
   })


### PR DESCRIPTION
This adds a new `@provideAsync` decorator which is complementary to `@provide`. This decorator resolves promises automatically, avoiding any awkward handling of Promises inside `@consume` getters.

(This is for 2.0 - but this is in the main branch to make merges into 2.0 easier).