### PR TITLE
keep hidden items hidden in sidebar and prev/next

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -2,14 +2,12 @@
   <nav class="position-sticky top-100px">
     <ol class="f3-light ml-4">
       {% for item in sidebarItems %}
-      {% unless item.hidden %}
       <li class="py-1">
         <a href="{{ site.baseurl }}{{ item.url }}">{{ item.title || item.name }}</a>
         {% if item.subtitle %}
         <span class="d-block text-gray-light f5">{{ item.subtitle }}</span>
         {% endif %}
       </li>
-      {% endunless %}
       {% endfor %}
     </ol>
   </nav>

--- a/docs/_layouts/guide.html
+++ b/docs/_layouts/guide.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% assign sidebarItems = site.guide | sort: 'chapter' %}
+{% assign sidebarItems = site.guide | where_exp: "item", "item.hidden != true" | sort: 'chapter' %}
 
 {% for item in sidebarItems  %}
   {% if item.title == page.title %}


### PR DESCRIPTION
This tweaks the `sidebarItems` array to _exclude_ any guide pages which are `hidden: true`. This fixes #285 