### PR TITLE
Separate v2 docs

### DIFF
--- a/docs/_guide/abilities.md
+++ b/docs/_guide/abilities.md
@@ -1,7 +1,7 @@
 ---
 chapter: 14
 subtitle: Abilities
-hidden: true
+version: 2
 ---
 
 Under the hood Catalyst's controller decorator is comprised of a handful of separate "abilities". An "ability" is essentially a mixin or perhaps "higher order class". An ability takes a class and returns an extended class that adds additional behaviours. By convention all abilities exported by Catalyst are suffixed with `able` which we think is a nice way to denote that something is an ability and should be used as such.

--- a/docs/_guide/abilities.md
+++ b/docs/_guide/abilities.md
@@ -1,7 +1,9 @@
 ---
-chapter: 14
-subtitle: Abilities
 version: 2
+chapter: 4
+title: Abilities
+subtitle: Abilities
+permalink: /guide-v2/abilities
 ---
 
 Under the hood Catalyst's controller decorator is comprised of a handful of separate "abilities". An "ability" is essentially a mixin or perhaps "higher order class". An ability takes a class and returns an extended class that adds additional behaviours. By convention all abilities exported by Catalyst are suffixed with `able` which we think is a nice way to denote that something is an ability and should be used as such.

--- a/docs/_guide/actions-2.md
+++ b/docs/_guide/actions-2.md
@@ -1,0 +1,201 @@
+---
+version: 2
+chapter: 6
+title: Actionable
+subtitle: Binding Events
+permalink: /guide-v2/actions
+---
+
+Catalyst Components automatically bind actions upon instantiation. Automatically as part of the `connectedCallback`, a component will search for any children with the `data-action` attribute, and bind events based on the value of this attribute. Any _public method_ on a Controller can be bound to via `data-action`.
+
+{% capture callout %}
+Remember! Actions are _automatically_ bound using the `@controller` decorator. There's no extra JavaScript code needed.
+{% endcapture %}{% include callout.md %}
+
+### Example
+
+<div class="d-flex my-4">
+  <div class="">
+
+<!-- annotations
+data-action "click.*": Will call `greetSomeone()` when clicked
+-->
+
+```html
+<hello-world>
+  <input
+    data-target="hello-world.name"
+    type="text"
+  >
+
+  <button
+    data-action="click:hello-world#greetSomeone">
+    Greet Someone
+  </button>
+
+  <span
+    data-target="hello-world.output">
+  </span>
+</hello-world>
+```
+
+  </div>
+  <div class="ml-4">
+
+<!-- annotations
+greetSomeone: All public methods can be called with `data-action`
+-->
+
+```js
+import { controller, target } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @target name: HTMLElement
+  @target output: HTMLElement
+
+  greetSomeone() {
+    this.output.textContent =
+      `Hello, ${this.name.value}!`
+  }
+}
+```
+
+  </div>
+</div>
+
+### Actions Syntax
+
+The actions syntax follows a pattern of `event:controller#method`.
+
+ - `event` must be the name of a [_DOM Event_](https://developer.mozilla.org/en-US/docs/Web/Events), e.g. `click`.
+ - `controller` must be the name of a controller ascendant to the element.
+ - `method` (optional) must be a _public_ _method_ attached to a controller's prototype. Static methods will not work.
+
+If method is not supplied, it will default to `handleEvent`.
+
+Some examples of Actions Syntax:
+
+- `click:my-element#foo` -> `click` events will call `foo` on `my-element` elements.
+- `submit:my-element#foo` -> `submit` events will call `foo` on `my-element` elements.
+- `click:user-list` -> `click` events will call `handleEvent` on `user-list` elements.
+- `click:user-list#` -> `click` events will call `handleEvent` on `user-list` elements.
+- `click:top-header-user-profile#` -> `click` events will call `handleEvent` on `top-header-user-profile` elements.
+- `nav:keydown:user-list` -> `navigation:keydown` events will call `handleEvent` on `user-list` elements.
+
+### Multiple Actions
+
+Multiple actions can be bound to multiple events, methods, and controllers. For example:
+
+<!-- annotations
+data-action: Fires all of these methods depending on the event
+-->
+
+```html
+<analytics-tracking>
+  <hello-world>
+    <input
+      data-target="hello-world.name"
+      data-action="
+        input:hello-world#validate
+        blur:hello-world#validate
+        focus:analytics-tracking#focus
+      "
+      type="text"
+    >
+
+    <button
+      data-action="
+        click:hello-world#greetSomeone
+        click:analytics-tracking#click
+        mouseover:analytics-tracking#hover
+      "
+    >
+      Greet Someone
+    </button>
+  </hello-world>
+</analytics-tracking>
+```
+
+### Custom Events
+
+A Controller may emit custom events, which may be listened to by other Controllers using the same Actions Syntax. There is no extra syntax needed for this. For example a `lazy-loader` Controller might dispatch a `loaded` event, once its contents are loaded, and other controllers can listen to this event:
+
+<!-- annotations
+data-action "loaded: Calls enable() on the `loaded` custom event
+-->
+
+```html
+<hover-card disabled>
+  <lazy-loader data-url="/user/1" data-action="loaded:hover-card#enable">
+    <loading-spinner>
+  </lazy-loader>
+</hover-card>
+```
+
+<!-- annotations
+this . dispatchEvent . new CustomEvent . . loaded . . : Dispatches custom "loaded" event
+enable: All public methods can be called with `data-action`
+-->
+
+```js
+import {controller} from '@github/catalyst'
+
+@controller
+class LazyLoader extends HTMLElement {
+
+  connectedCallback() {
+    this.innerHTML = await (await fetch(this.dataset.url)).text()
+    this.dispatchEvent(new CustomEvent('loaded'))
+  }
+
+}
+
+@controller
+class HoverCard extends HTMLElement {
+
+  enable() {
+    this.disabled = false
+  }
+
+}
+```
+
+### Targets and "ShadowRoots"
+
+Custom elements can create encapsulated DOM trees known as "Shadow" DOM. Catalyst actions support Shadow DOM by traversing the `shadowRoot`, if present, and also automatically watching shadowRoots for changes; auto-binding new elements as they are added.
+
+### What about without Decorators?
+
+If you're using decorators, then the `@controller` decorator automatically handles binding of actions to a Controller.
+
+If you're not using decorators, then you'll need to call `bind(this)` somewhere inside of `connectedCallback()`.
+
+```js
+import {bind} from '@github/catalyst'
+
+class HelloWorldElement extends HTMLElement {
+  connectedCallback() {
+    bind(this)
+  }
+}
+```
+
+### Binding dynamically added actions
+
+Catalyst automatically listens for elements that are dynamically injected into the DOM, and will bind any element's `data-action` attributes. It does this by calling `listenForBind(controller.ownerDocument)`. If for some reason you need to observe other documents (such as mutations within an iframe), then you can call the `listenForBind` manually, passing a `Node` to listen to DOM mutations on.
+
+```js
+import {listenForBind} from '@github/catalyst'
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @target iframe: HTMLIFrameElement
+
+  connectedCallback() {
+    // listenForBind(this.ownerDocument) is automatically called.
+
+    listenForBind(this.iframe.document.body)
+  }
+}
+```

--- a/docs/_guide/actions.md
+++ b/docs/_guide/actions.md
@@ -1,5 +1,7 @@
 ---
-chapter: 6
+version: 1
+chapter: 5
+title: Actions
 subtitle: Binding Events
 ---
 

--- a/docs/_guide/anti-patterns-2.md
+++ b/docs/_guide/anti-patterns-2.md
@@ -1,0 +1,367 @@
+---
+version: 2
+chapter: 13
+title: Anti Patterns
+subtitle: Things to avoid building components
+permalink: /guide-v2/anti-patterns
+---
+
+{% capture octx %}<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm8.036-4.024a.75.75 0 00-1.06 1.06L10.939 12l-2.963 2.963a.75.75 0 101.06 1.06L12 13.06l2.963 2.964a.75.75 0 001.061-1.06L13.061 12l2.963-2.964a.75.75 0 10-1.06-1.06L12 10.939 9.036 7.976z"></path></svg>{% endcapture %}
+{% capture octick %}<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm16.28-2.72a.75.75 0 00-1.06-1.06l-5.97 5.97-2.47-2.47a.75.75 0 00-1.06 1.06l3 3a.75.75 0 001.06 0l6.5-6.5z"></path></svg>{% endcapture %}
+{% capture discouraged %}<h4 class="text-red">{{ octx }} Discouraged</h4>{% endcapture %}
+{% capture encouraged %}<h4 class="text-green">{{ octick }} Encouraged</h4>{% endcapture %}
+
+Here are a few common anti-patterns which we've discovered as developers have used Catalyst. We consider these anti-patterns as they're best avoided, because of surprising edge-cases, or simply because there are easier ways to achieve the same goals.
+
+### Avoid doing any initialisation in the constructor
+
+With conventional classes, it is expected that initialisation will be done in the `constructor()` method. Custom Elements are slightly different, because the `constructor` is called _before_ the element has been put into the Document, which means any initialisation that expects to be connected to a DOM will fail. 
+
+{{ discouraged }}
+
+```typescript
+import { controller } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  constructor() {
+    // This will fire before DOM is connected, so will never bubble!
+    this.dispatchEvent(new CustomEvent('loaded'))
+  }
+}
+```
+
+{{ encouraged }}
+
+```typescript
+import { controller } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  connectedCallback() {
+    // This will fire _after_ DOM is connected, so will bubble up as expected
+    this.dispatchEvent(new CustomEvent('loaded'))
+  }
+}
+```
+
+
+### Avoid interacting with parents, use Events where possible
+
+Sometimes it's necessary to let ancestors know about the state of a child element, for example when an element loads or needs the parent to change somehow. Sometimes it can be tempting to use methods like `this.closest()` to get a reference to the parent element and interact with it directly, but this creates a fragile coupling to elements and is best avoided. Events can used here, instead:
+
+{{ discouraged }}
+
+<div class="d-flex my-4">
+  <div class="">
+
+```typescript
+import { controller } from "@github/catalyst"
+
+@controller
+class UserSettingsElement extends HTMLElement {
+  loading() {
+    // While this is loading we need to disable
+    // the whole User if `user-profile` ever
+    // changes, this code will break!
+    this
+      .closest('user-profile')
+      .disable()
+  }
+}
+```
+
+  </div><div class="ml-4">
+
+```html
+<user-profile>
+  <user-settings></user-settings>
+</user-profile>
+```
+
+  </div>
+</div>
+
+Instead of interacting with the parent's API directly in JS, you can use `Events` which can be listened to with `data-action`, this moves any coupling into the HTML which already has the association, and so subsequent refactors will have far less risk of breaking the code:
+
+{{ encouraged }}
+
+<div class="d-flex my-4">
+  <div class="">
+
+```typescript
+import { controller } from "@github/catalyst"
+
+@controller
+class UserSettingsElement extends HTMLElement {
+  loading() {
+    this.dispatchEvent(
+      new CustomEvent('loading')
+    )
+  }
+}
+```
+
+  </div><div class="ml-4">
+
+```html
+<user-profile>
+  <user-settings
+    data-action="loading:user-profile#disable">
+  </user-settings>
+</user-profile>
+```
+
+  </div>
+</div>
+
+### Avoid shadowing method names
+
+When naming a method, you should avoid naming it something that already exists on the `HTMLElement` prototype; as doing so can lead to surprising behaviors. Test out the form below to see what method names are allowed or not:
+
+<form>
+  <label>
+    <h4>I want my method to be called...</h4>
+    <input class="js-methodname-shadow-test mb-4">
+  </label>
+  <div hidden class="js-methodname-shadow-bad-input text-red">
+    {{ octx }} This name would shadow <code></code>, you'll need to pick a different name
+  </div>
+  <div hidden class="js-methodname-shadow-warn-input text-orange-light">
+    {{ octx }} While this name is allowed, it's not ideal because <span></span>. You should consider a different name.
+  </div>
+  <div hidden class="js-methodname-shadow-good-input text-green">
+    {{ octick }} This is a good name for a method!
+  </div>
+  <script>
+    const warnings = {
+      'new': 'it has a special meaning in JS',
+      'super': 'it has a special meaning in JS',
+      'prototype': 'it has a special meaning in JS',
+      'requestSubmit': 'it is a proposed new feature',
+    }
+    document.querySelector('.js-methodname-shadow-test').addEventListener('input', () => {
+      const name = event.target.value
+      const goodEl = document.querySelector('.js-methodname-shadow-good-input')
+      const badEl = document.querySelector('.js-methodname-shadow-bad-input')
+      const warnEl = document.querySelector('.js-methodname-shadow-warn-input')
+      if (name === '') {
+        goodEl.hidden = true
+        return
+      }
+      let warning = warnings[name]
+      if (name !== name.toLowerCase() && name.toLowerCase() in HTMLElement.prototype) {
+        warning = `it is too similar to \`${name.toLowerCase()}\` which already exists`
+      } else if (name.startsWith('on') && !(name in HTMLElement.prototype)) {
+        warning = 'starting with `on` suggests a coupling between the event and the method (see below)'
+      }
+      goodEl.hidden = warning || (name in HTMLElement.prototype)
+      warnEl.hidden = !warning
+      badEl.hidden = warning || !(name in HTMLElement.prototype)
+      if (warning) {
+        warnEl.querySelector('span').textContent = warning
+      } else if (name in HTMLElement.prototype) {
+        let proto = HTMLElement.prototype
+        while(proto !== null) {
+          if (proto.hasOwnProperty(name)) break
+          proto = Object.getPrototypeOf(proto)
+        }
+        badEl.querySelector('code').textContent = `${proto.constructor.name}.prototype.${name}`
+      }
+    })
+  </script>
+</form>
+
+### Avoid naming methods after events, e.g. `onClick`
+
+When you have a method which is only called as an event, it is tempting to name that method based off of the event, e.g. `onClick`, `onInputFocus`, and so on. This name implies a coupling between the event and method, which later refactorings may break. Also names like `onClick` are very close to `onclick` which is already [part of the Element's API](https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onclick). Instead we recommend naming the method after what it does, not how it is called, for example `resetForm`:
+
+{{ discouraged }}
+
+<div class="d-flex my-4">
+  <div class="">
+
+```js
+import { controller } from "@github/catalyst"
+
+@controller
+class UserLoginElement extends HTMLElement {
+
+  // `onClick` is not clear
+  onClick() {
+    // Log the user in
+  }
+}
+```
+
+  </div>
+  <div class="ml-4">
+
+```html
+<user-login>
+  <!-- ... -->
+  <button
+    data-action="click:user-login#onClick">
+    <!-- `onClick` is not clear -->
+    Log In
+  </button>
+</user-login>
+```
+
+  </div>
+</div>
+
+{{ encouraged }}
+
+<div class="d-flex my-4">
+  <div class="">
+
+```js
+import { controller } from "@github/catalyst"
+
+@controller
+class UserLoginElement extends HTMLElement {
+
+  login() {
+    // Log the user in
+  }
+}
+```
+
+  </div>
+  <div class="ml-4">
+
+```html
+<user-login>
+  <!-- ... -->
+  <button
+    data-action="click:user-login#login">
+    Log In
+  </button>
+</user-login>
+```
+
+  </div>
+</div>
+
+### Avoid querying against your element, use `@target` or `@targets`
+
+We find it very common for developers to return to habits and use `querySelector[All]` when needing to get elements. The `@target` and `@targets` decorators were designed to simplify `querySelector[All]` and avoid certain bugs with them (such as nesting issues, and unnecessary coupling) so it's a good idea to use them as much as possible:
+
+{{ discouraged }}
+
+```typescript
+class UserListElement extends HTMLElement {
+  showAdmins() {
+    // Just need to get admins here...
+    for (const user of this.querySelector('[data-is-admin]')) {
+      user.hidden = false
+    }
+  }
+}
+```
+
+{{ encouraged }}
+
+```typescript
+class UserList {
+  @targets admins: HTMLElement[]
+
+  showAdmins() {
+    // Just need to get admins here...
+    for (const user of this.admins) {
+      user.hidden = false
+    }
+  }
+}
+```
+
+
+### Avoid filtering `@targets`, use another `@target` or `@targets`
+
+
+Sometimes you might need to get a subset of elements from a `@targets` selector. When doing this, simply use another `@target` or `@targets` attribute, it's okay to have many of these! Adding getters which simply return a `@targets` subset has various drawbacks which make it an anti pattern.
+
+For example let's say we have a list of filter checkboxes and checking the "all" checkbox unchecks all other checkboxes:
+
+{{ discouraged }}
+
+```typescript
+@controller
+class UserFilter {
+  @targets filters: HTMLInputElement[]
+
+  get allFilter() {
+    return this.filters.find(el => el.matches('[data-filter="all"]'))
+  }
+
+  filter(event: Event) {
+    if (event.target === this.allFilter) {
+      for(const filter of this.filters) {
+        if (filter !== this.allFilter) filter.checked = false
+      }
+    }
+    // ...
+  }
+
+}
+```
+
+```html
+<user-filter>
+  <label><input type="checkbox"
+    data-action="change:user-filter#filter"
+    data-targets="user-filter.filters"
+    data-filter="all">Show all</label>
+  <label><input type="checkbox"
+    data-action="change:user-filter#filter"
+    data-targets="user-filter.filters"
+    data-filter="new">New Users</label>
+  <label><input type="checkbox"
+    data-action="change:user-filter#filter"
+    data-targets="user-filter.filters"
+    data-filter="admin">Admins</label>
+  <!-- ... --->
+</user-filter>
+```
+
+While this works well, it could be more easily solved with targets:
+
+{{ encouraged }}
+
+```typescript
+@controller
+class UserFilter {
+  @targets filters: HTMLInputElement[]
+  @target allFilter: HTMLInputElement
+
+  filter(event: Event) {
+    if (event.target === this.allFilter) {
+      for (const filter of this.filters) {
+        if (filter !== this.allFilter) filter.checked = false
+      }
+    }
+    // ...
+  }
+
+}
+```
+
+```html
+<user-filter>
+  <label><input type="checkbox"
+    data-action="change:user-filter#filter"
+    data-target="user-filter.allFilter"
+    data-targets="user-filter.filters"
+    data-filter="all">Show all</label>
+  <label><input type="checkbox"
+    data-action="change:user-filter#filter"
+    data-targets="user-filter.filters"
+    data-filter="new">New Users</label>
+  <label><input type="checkbox"
+    data-action="change:user-filter#filter"
+    data-targets="user-filter.filters"
+    data-filter="admin">Admins</label>
+  <!-- ... --->
+</user-filter>
+```

--- a/docs/_guide/anti-patterns.md
+++ b/docs/_guide/anti-patterns.md
@@ -1,6 +1,8 @@
 ---
-chapter: 12
-subtitle: Anti Patterns
+version: 1
+chapter: 11
+title: Anti Patterns
+subtitle: Things to avoid building components
 ---
 
 {% capture octx %}<svg class="octicon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill-rule="evenodd" d="M1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12zm8.036-4.024a.75.75 0 00-1.06 1.06L10.939 12l-2.963 2.963a.75.75 0 101.06 1.06L12 13.06l2.963 2.964a.75.75 0 001.061-1.06L13.061 12l2.963-2.964a.75.75 0 10-1.06-1.06L12 10.939 9.036 7.976z"></path></svg>{% endcapture %}

--- a/docs/_guide/attrs-2.md
+++ b/docs/_guide/attrs-2.md
@@ -1,0 +1,220 @@
+---
+version: 2
+chapter: 7
+title: Attrable
+subtitle: Using attributes as configuration
+permalink: /guide-v2/attrs
+---
+
+Components may sometimes manage state, or configuration. We encourage the use of DOM as state, rather than maintaining a separate state. One way to maintain state in the DOM is via [Attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes).
+
+As Catalyst elements are really just Web Components, they have the `hasAttribute`, `getAttribute`, `setAttribute`, `toggleAttribute`, and `removeAttribute` set of methods available, as well as [`dataset`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/dataset), but these can be a little tedious to use; requiring null checking code with each call.
+
+Catalyst includes the `@attr` decorator, which provides nice syntax sugar to simplify, standardise, and encourage use of attributes. `@attr` has the following benefits over the basic `*Attribute` methods:
+
+ - It maps whatever the property name is to `data-*`, [similar to how `dataset` does](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/dataset#name_conversion), but with more intuitive naming (e.g. `URL` maps to `data-url` not `data--u-r-l`).
+ - An `@attr` property is limited to `string`, `boolean`, or `number`, it will never be `null` or `undefined` - instead it has an "empty" value. No more null checking!
+ - The attribute name is automatically [observed, meaning `attributeChangedCallback` will fire when it changes](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks).
+ - Assigning a value in the class description will make that value the _default_ value, so when the element is connected that value is set (unless the element has the attribute defined already).
+
+To use the `@attr` decorator, attach it to a class field, and it will get/set the value of the matching `data-*` attribute.
+
+### Example
+
+<!-- annotations
+attr foo: Maps to get/setAttribute('datafoo')
+-->
+
+```js
+import { controller, attr } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @attr foo = 'hello'
+}
+```
+
+This is the equivalent to:
+
+```js
+import { controller } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  get foo(): string {
+    return this.getAttribute('data-foo') || ''
+  }
+
+  set foo(value: string): void {
+    return this.setAttribute('data-foo', value)
+  }
+
+  connectedCallback() {
+    if (!this.hasAttribute('data-foo')) this.foo = 'Hello'
+  }
+
+  static observedAttributes = ['data-foo']
+}
+```
+
+### Attribute Types
+
+The _type_ of an attribute is automatically inferred based on the type it is first set to. This means once a value is set it cannot change type; if it is set a `string` it will never be anything but a `string`. An attribute can only be one of either a `string`, `number`, or `boolean`. The types have small differences in how they behave in the DOM.
+
+Below is a handy reference for the small differences, this is all explained in more detail below that. 
+
+| Type      | "Empty" value | When `get` is called | When `set` is called |
+|:----------|:--------------|----------------------|:---------------------|
+| `string`  | `''`          | `getAttribute`       | `setAttribute`       |
+| `number`  | `0`           | `getAttribute`       | `setAttribute`       |
+| `boolean` | `false`       | `hasAttribute`       | `toggleAttribute`    |
+
+#### String Attributes
+
+If an attribute is first set to a `string`, then it can only ever be a `string` during the lifetime of an element. The property will return an empty string (`''`) if the attribute doesn't exist, and trying to set it to something that isn't a string will turn it into one before assignment.
+
+<!-- annotations
+attr foo: Maps to get/setAttribute('data-foo')
+-->
+
+```js
+import { controller, attr } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @attr foo = 'Hello'
+
+  connectedCallback() {
+    console.assert(this.foo === 'Hello')
+    this.foo = null // TypeScript won't like this!
+    console.assert(this.foo === 'null')
+    delete this.dataset.foo // Removes the attribute
+    console.assert(this.foo === '') // If the attribute doesn't exist, its an empty string!
+  }
+}
+```
+
+#### Boolean Attributes
+
+If an attribute is first set to a boolean, then it can only ever be a boolean during the lifetime of an element. Boolean properties check for _presence_ of an attribute, sort of like how [`required`, `disabled` & `readonly` attributes work on forms](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes) The property will return `false` if the attribute doesn't exist, and `true` if it does, regardless of the value. If the property is set to `false` then `removeAttribute` is called, whereas `setAttribute(name, '')` is called when setting to a truthy value.
+
+<!-- annotations
+attr foo: Maps to has/toggleAttribute('data-foo')
+-->
+
+```js
+import { controller, attr } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @attr foo = false
+
+  connectedCallback() {
+    console.assert(this.hasAttribute('data-foo') === false)
+    this.foo = true
+    console.assert(this.hasAttribute('data-foo') === true)
+    this.setAttribute('data-foo', 'this value doesnt matter!')
+    console.assert(this.foo === true)
+  }
+}
+```
+
+#### Number Attributes
+
+If an attribute is first set to a number, then it can only ever be a number during the lifetime of an element. This is sort of like the [`maxlength` attribute on inputs](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength). The property will return `0` if the attribute doesn't exist, and will be coerced to `Number` if it does - this means it is _possible_ to get back `NaN`. Negative numbers and floats are also valid.
+
+<!-- annotations
+attr foo: Maps to get/setAttribute('data-foo')
+-->
+
+```js
+import { controller, attr } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @attr foo = 1
+
+  connectedCallback() {
+    console.assert(this.getAttribute('data-foo') === '1')
+    this.setAttribute('data-foo', 'not a number')
+    console.assert(Number.isNaN(this.foo))
+    this.foo = -3.14
+    console.assert(this.getAttribute('data-foo') === '-3.14')
+  }
+}
+```
+
+### Default Values
+
+When an element gets connected to the DOM, the attr is initialized. During this phase Catalyst will determine if the default value should be applied. The default value is defined in the class property. The basic rules are as such:
+
+ - If the class property has a value, that is the _default_
+ - When connected, if the element _does not_ have a matching attribute, the default _is_ applied.
+ - When connected, if the element _does_ have a matching attribute, the default _is not_ applied, the property will be assigned to the value of the attribute instead.
+
+{% capture callout %}
+Remember! The values defined in the class field are the _default_. They won't be set if the element is created and its attribute set to a custom value!
+{% endcapture %}{% include callout.md %}
+
+The following example illustrates this behavior:
+
+<!-- annotations
+attr name: Maps to get/setAttribute('data-name')
+-->
+
+```js
+import { controller, attr } from "@github/catalyst"
+@controller
+class HelloWorldElement extends HTMLElement {
+  @attr name = 'World'
+  connectedCallback() {
+    this.textContent = `Hello ${this.name}`
+  }
+}
+```
+
+<!-- annotations
+data-name ".*": Will set the value of `name`
+-->
+
+```html
+<hello-world></hello-world>
+// This will render `Hello World`
+
+<hello-world data-name="Catalyst"></hello-world>
+// This will render `Hello Catalyst`
+
+<hello-world data-name=""></hello-world>
+// This will render `Hello `
+```
+
+### What about without Decorators?
+
+If you're not using decorators, then you won't be able to use the `@attr` decorator, but there is still a way to achieve the same result. Under the hood `@attr` simply tags a field, but `initializeAttrs` and `defineObservedAttributes` do all of the logic.
+
+Calling `initializeAttrs` in your connected callback, with the list of properties you'd like to initialize, and calling `defineObservedAttributes` with the class, can achieve the same result as `@attr`. The class fields can still be defined in your class, and they'll be overridden as described above. For example:
+
+```js
+import {initializeAttrs, defineObservedAttributes} from '@github/catalyst'
+
+class HelloWorldElement extends HTMLElement {
+  foo = 1
+
+  connectedCallback() {
+    initializeAttrs(this, ['foo'])
+  }
+
+}
+defineObservedAttributes(HelloWorldElement, ['foo'])
+```
+
+This example is functionally identical to:
+
+```js
+import {controller, attr} from '@github/catalyst'
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @attr foo = 1
+}
+```

--- a/docs/_guide/attrs.md
+++ b/docs/_guide/attrs.md
@@ -1,5 +1,7 @@
 ---
-chapter: 7
+version: 1
+chapter: 6
+title: Attrs
 subtitle: Using attributes as configuration
 ---
 

--- a/docs/_guide/conventions.md
+++ b/docs/_guide/conventions.md
@@ -1,6 +1,8 @@
 ---
-chapter: 10
-subtitle: Conventions
+version: 1
+chapter: 9
+title: Conventions
+subtitle: Common naming and patterns
 ---
 
 Catalyst strives for convention over code. Here are a few conventions we recommend when writing Catalyst code:

--- a/docs/_guide/create-ability.md
+++ b/docs/_guide/create-ability.md
@@ -1,7 +1,8 @@
 ---
-chapter: 16 
-subtitle: Create your own abilities
 version: 2
+chapter: 9
+title: Create Ability
+subtitle: Create your own abilities
 ---
 
 Catalyst provides the functionality to create your own abilities, with a few helper methods and a `controllable` base-level ability. These are explained in detail below, but for a quick summary they are:

--- a/docs/_guide/create-ability.md
+++ b/docs/_guide/create-ability.md
@@ -1,7 +1,7 @@
 ---
 chapter: 16 
 subtitle: Create your own abilities
-hidden: true
+version: 2
 ---
 
 Catalyst provides the functionality to create your own abilities, with a few helper methods and a `controllable` base-level ability. These are explained in detail below, but for a quick summary they are:

--- a/docs/_guide/decorators-2.md
+++ b/docs/_guide/decorators-2.md
@@ -1,0 +1,129 @@
+---
+version: 2
+chapter: 3
+title: Decorators
+subtitle: Using TypeScript for ergonomics
+permalink: /guide-v2/decorators
+---
+
+Decorators are used heavily in Catalyst, because they provide really clean ergonomics and makes using the library a lot easier. Decorators are a special, (currently) non standard, feature of TypeScript. You'll need to turn the `experimentalDecorators` option on inside of your TypeScript project to use them (if you're using `@babel/plugin-proposal-decorators` plugin, you need to use [`legacy` option](https://babeljs.io/docs/en/babel-plugin-proposal-decorators#legacy)).
+
+You can read more about [decorators in the TypeScript handbook](https://www.typescriptlang.org/docs/handbook/decorators.html), but here's quick guide:
+
+Decorators can be used three ways:
+
+### Class Decorators
+
+Catalyst comes with the `@controller` decorator. This gets put on top of the class, like so:
+
+```js
+@controller
+class HelloWorldElement extends HTMLElement {}
+```
+
+### Class Field Decorators
+
+Catalyst comes with the `@target` and `@targets` decorators (for more on these [read the Targets guide section]({{ site.baseurl }}/guide/targets)). These get added on top or to the left of the field name, like so:
+
+```js
+class HelloWorldElement extends HTMLElement {
+
+  @target something
+  
+  // Alternative style
+  @targets
+  others
+
+}
+```
+<br>
+
+Class Field decorators get given the class and the field name so they can add custom functionality to the field. Because they operate on the fields, they must be put on top of or to the left of the field.
+
+### Method Decorators
+
+Method decorators work just like Field Decorators. Put them on top or on the left of the method, like so:
+
+
+```js
+class HelloWorldElement extends HTMLElement {
+
+  @log
+  submit() {
+    // ...
+  }
+
+  // Alternative style
+
+  @log load() {
+    // ...
+  }
+
+}
+```
+
+### Getter/Setter 
+
+Decorators can also be used over a `get` or `set` field. These work just like Field Decorators, but you can put them over one or both the `get` or `set` field. Some decorators might throw an error if you put them over a `get` field, when they expect to be put over a `set` field:
+
+
+```js
+class HelloWorldElement extends HTMLElement {
+
+  @target set something() {
+    // ...
+  }
+
+  // Can be used over just one field
+  @attr get data() {
+    return {}
+  }
+  set data() {
+
+  }
+}
+```
+
+### Supporting `strictPropertyInitialization`
+
+TypeScript comes with various "strict" mode settings, one of which is `strictPropertyInitialization` which lets TypeScript catch potential class properties which might not be assigned during construction of a class. This option conflicts with Catalyst's `@target`/`@targets` decorators, which safely do the assignment but TypeScript's simple heuristics cannot detect this. There are two ways to work around this:
+
+1. Use TypeScript's [`declare` modifier](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) to tell TypeScript that the decorated field will still be set up correctly:
+
+    ```typescript
+    class HelloWorldElement extends HTMLElement {
+      @target declare something: HTMLElement
+      @targets declare items: HTMLElement[]
+    }
+    ```
+    
+    Note that this only works on TypeScript 3.7+, so if you're on an older version, you can also use the [definite initialization operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-7.html#definite-assignment-assertions) to do the same thing.
+
+2. You can also disable the compiler option (other strict mode rules can still apply) in your `tsconfig.json` like so:
+
+    ```json
+    {
+      "compilerOptions": {
+        "strict": true,
+        "strictPropertyInitialization": false
+      }
+    }
+    ```
+
+### Function Calling Decorators
+
+You might see some decorators that look like function calls, and that's because they are! Some decorators allow for customisation; calling with additional arguments. Decorators that expect to be called are generally not interchangeable with the non-call variant, a decorators documentation should tell you how to use it.
+
+Catalyst doesn't ship with any decorators that can be called like a function; but an example of one can be found in the `@debounce` decorator in the [`@github/mini-throttle`](https://github.com/github/mini-throttle) package:
+
+```js
+class HelloWorldElement extends HTMLElement {
+
+  @debounce(100)
+  handleInput() {
+    // ...
+  }
+
+}
+```
+<br>

--- a/docs/_guide/decorators.md
+++ b/docs/_guide/decorators.md
@@ -1,5 +1,7 @@
 ---
-chapter: 4
+version: 1
+chapter: 3
+title: Decorators
 subtitle: Using TypeScript for ergonomics
 ---
 

--- a/docs/_guide/introduction-2.md
+++ b/docs/_guide/introduction-2.md
@@ -1,0 +1,29 @@
+---
+version: 2
+chapter: 1
+title: Introduction
+subtitle: Origins & Concepts
+permalink: /guide-v2/introduction
+---
+
+Catalyst is a set of patterns and techniques for developing _components_ within a complex application. At its core, Catalyst simply provides a small library of functions to make developing [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) easier. The library is an implementation detail, though. The concepts are what we're most interested in.
+
+## How did we get here?
+
+GitHub's first page interactions were written using jQuery, which was widely used at the time. Eventually, as browser compatibility increased and jQuery patterns such as the Selector Pattern & easy class manipulation became standard, [GitHub moved away from jQuery](https://github.blog/2018-09-06-removing-jquery-from-github-frontend/).
+
+Rather than moving to entirely new paradigms, GitHub continued to use the same concepts within jQuery. Event Delegation was still heavily used, as well as querySelector. The event delegation concept was also extended to "element delegation" - discovering when Elements were added to the DOM, using the [Selector Observer](https://github.com/josh/selector-observer) library.
+
+These patterns were reduced to first principles: _Observing_ elements on the page, _listening_ to the events these elements or their children emit, and _querying_ the children of an element to mutate or extend them.
+
+The Web Systems team at GitHub explored other tools that adopt these set of patterns and principles. The closest match to those goals was [Stimulus](https://stimulusjs.org/) (from which Catalyst is heavily inspired), but ultimately the desire to leverage technology that engineers at GitHub were already familiar with was the motivation to create Catalyst.
+
+## Three core concepts: Observe, Listen, Query
+
+Catalyst takes these three core concepts and delivers them in the lightest possible way they can be delivered.
+
+ - **Observability** Catalyst solves observability by leveraging [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements). Custom Elements are given unique names within a system, and the browser will automatically use the Custom Element registry to observe these Elements entering and leaving the DOM. Read more about this in the Guide Section entitled [Your First Component]({{ site.baseurl }}/guide/your-first-component).
+
+ - **Listening** Event Delegation makes a great deal of sense when observing events "high up the tree" - registering global event listeners on the Window element - but Custom Elements sit much closer to their children within the tree, and so Direct Event binding is preferred. Catalyst solves this by binding event listeners to any descendants with `data-action` attributes. Read more about this in the Guide Section entitled [Actions]({{ site.baseurl }}/guide/actions).
+
+ - **Querying** Custom Elements largely solve querying, by simply calling `querySelector` - however CSS selectors are loosely disciplined and can create unnecessary coupling to the DOM structure (e.g. by querying tag names). Catalyst extends the `data-action` concept by also using `data-target` to declare descendants that the Custom Element is interested in querying. Read more about this in the Guide Section entitled [Targets]({{ site.baseurl }}/guide/targets).

--- a/docs/_guide/introduction.md
+++ b/docs/_guide/introduction.md
@@ -1,6 +1,8 @@
 ---
-subtitle: Origins & Concepts
+version: 1
 chapter: 1
+title: Introduction
+subtitle: Origins & Concepts
 ---
 
 Catalyst is a set of patterns and techniques for developing _components_ within a complex application. At its core, Catalyst simply provides a small library of functions to make developing [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) easier. The library is an implementation detail, though. The concepts are what we're most interested in.

--- a/docs/_guide/lazy-elements-2.md
+++ b/docs/_guide/lazy-elements-2.md
@@ -1,0 +1,34 @@
+---
+version: 2
+chapter: 15
+title: Lazy Elements
+subtitle: Dynamically load elements just in time
+---
+
+A common practice in modern web development is to combine all JavaScript code into JS "bundles". By bundling the code together we avoid the network overhead of fetching each file. However the trade-off of bundling is that we might deliver JS code that will never run in the browser.
+
+![A screenshot from Chrome Devtools showing the Coverage panel. The panel has multiple request to JS assets and it shows that most of them have large chunks that are unused.](/catalyst/guide/devtools-coverage.png)
+
+An alternative solution to bundling is to load JavaScript just in time. Downloding the JavaScript for Catalyst controllers when the browser first encounters them can be done with the `lazyDefine` function.
+
+```typescript
+import {lazyDefine} from '@github/catalyst'
+
+// Dynamically import the Catalyst controller when the `<user-avatar>` tag is seen.
+lazyDefine('user-avatar', () => import('./components/user-avatar'))
+```
+
+Serving this file allows us to defer loading of the component code until it's actually needed by the web page. The tradeoff of deferring loading is that the elements will be inert until the dynamic import of the component code resolves. Consider what your UI might look like while these components are resolving. Consider providing a loading indicator and disabling controls as the default state. The smaller the component, the faster it will resolve which means that your users might not notice a inert state. A good rule of thumb is that a component should load within 100ms on a "Fast 3G" connection.
+
+Generally we think it's a good idea to `lazyDefine` all elements and then prioritize eager loading of ciritical elements as needed. You might consider using code-generation to generate a file lazy defining all your components.
+
+By default the component will be loaded when the element is present in the document and the document has finished loading. This can happen before sub-resources such as scripts, images, stylesheets and frames have finished loading. It is possible to defer loading even later by adding a `data-load-on` attribute on your element. The value of which must be one of the following prefefined values:
+
+- `<user-avatar data-load-on="ready"></user-avatar>` (default)
+	- The element is loaded when the document has finished loading. This listens for changes to `document.readyState` and triggers when it's no longer loading.
+- `<user-avatar data-load-on="firstInteraction"></user-avatar>` 
+	- This element is loaded on the first user interaction with the page. This listens for `mousedown`, `touchstart`, `pointerdown` and `keydown` events on `document`.
+- `<user-avatar data-load-on="visible"></user-avatar>`
+	- This element is loaded when it's close to being visible. Similar to `<img loading="lazy" [..] />` . The functionality is driven by an `IntersectionObserver`.
+
+This functionality is similar to the ["Lazy Custom Element Definitions" spec proposal](https://github.com/WICG/webcomponents/issues/782) and as this proposal matures we see Catalyst conforming to the spec and leveraging this new API to lazy load elements.

--- a/docs/_guide/lazy-elements.md
+++ b/docs/_guide/lazy-elements.md
@@ -1,5 +1,7 @@
 ---
-chapter: 17
+version: 1
+chapter: 13
+title: Lazy Elements
 subtitle: Dynamically load elements just in time
 ---
 

--- a/docs/_guide/lifecycle-hooks-2.md
+++ b/docs/_guide/lifecycle-hooks-2.md
@@ -1,0 +1,43 @@
+---
+version: 2
+chapter: 10
+title: Lifecycle Hooks
+subtitle: Observing the life cycle of an element
+permalink: /guide-v2/lifecycle-hooks
+---
+
+Catalyst Controllers - like many other frameworks - have several "well known" method names which are called periodically through the life cycle of the element, and let you observe when an element changes in various ways. Here is a comprehensive list of all life-cycle callbacks. Each one is suffixed `Callback`, to denote that it will be called by the framework.
+
+### `connectedCallback()`
+
+The [`connectedCallback()` is part of Custom Elements][ce-callbacks], and gets fired as soon as your element is _appended_ to the DOM. This callback is a good time to initialize any variables, perhaps add some global event listeners, or start making any early network requests.
+
+JavaScript traditionally uses the `constructor()` callback to listen for class creation. While this still works for Custom Elements, it is best avoided as the element won't be in the DOM when `constructor()` is fired, limiting its utility.
+
+#### Things to remember
+
+The `connectedCallback` is called _as soon as_ the element is attached to a `document`. This _may_ occur _before_ an element has any children appended to it, so you should be careful not expect an element to have children during a `connectedCallback` call. This means avoiding checking any `target`s or using other methods like `querySelector`. Instead use this function to initialize itself and avoid doing initialization work which depend on children existing.
+
+If your element depends heavily on its children existing, consider adding a [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) in the `connectedCallback` to track when your elements children change.
+
+### `attributeChangedCallback()`
+
+The [`attributeChangedCallback()` is part of Custom Elements][ce-callbacks], and gets fired when _observed attributes_ are added, changed, or removed from your element. It required you set a `static observedAttributes` array on your class, the values of which will be any attributes that will be observed for mutations. This is given a set of arguments, the signature of your function should be:
+
+```typescript
+attributeChangedCallback(name: string, oldValue: string|null, newValue: string|null): void {}
+```
+
+#### Things to remember
+
+The `attributeChangedCallback` will fire whenever `setAttribute` is called with an observed attribute, even if the _new_ value is the same as the _old_ value. In other words, it is possible for `attributeChangedCallback` to be called when `oldValue === newValue`. In most cases this really won't matter much, and in some cases this is very helpful; but sometimes this can bite, especially if you have [non-idempotent](https://en.wikipedia.org/wiki/Idempotence#Computer_science_examples) code inside your `attributeChangedCallback`. Try to make sure operations inside `attributeChangedCallback` are idempotent, or perhaps consider adding a check to ensure `oldValue !== newValue` before performing operations which may be sensitive to this.
+
+### `disconnectedCallback()`
+
+The [`disconnectedCallback()` is part of Custom Elements][ce-callbacks], and gets fired as soon as your element is _removed_ from the DOM. Event listeners will automatically be cleaned up, and memory will be freed automatically from JavaScript, so you're unlikely to need this callback for much.
+
+### `adoptedCallback()`
+
+The [`adoptedCallback()` is part of Custom Elements][ce-callbacks], and gets called when your element moves from one `document` to another (such as an iframe). It's very unlikely to occur, you'll almost never need this.
+
+[ce-callbacks]: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#Using_the_lifecycle_callbacks

--- a/docs/_guide/lifecycle-hooks.md
+++ b/docs/_guide/lifecycle-hooks.md
@@ -1,5 +1,7 @@
 ---
-chapter: 8
+version: 1
+chapter: 7
+title: Lifecycle Hooks
 subtitle: Observing the life cycle of an element
 ---
 

--- a/docs/_guide/patterns-2.md
+++ b/docs/_guide/patterns-2.md
@@ -1,0 +1,132 @@
+---
+version: 2
+chapter: 12
+title: Patterns
+subtitle: Best Practices for behaviours
+permalink: /guide-v2/patterns
+---
+
+An aim of Catalyst is to be as light weight as possible, and so we often avoid including helper functions for otherwise fine code. We also want to keep Catalyst focussed, and so where some helper functions might be reasonable, we recommend judicious use of other small libraries.
+
+Here are a few common patterns which we've avoided introducing into the Catalyst code base, and instead encourage you to take the example code and run with that:
+
+### Debouncing or Throttling events
+
+Often times you'll want to do something computationally intensive (or network intensive) based on a user event. It's worth throttling the amount of times a function can be called for these events, to prevent saturation of the CPU or network. For this we can use the "debounce" or "throttle" patterns. We recommend using the [`@github/mini-throttle`](https://github.com/github/mini-throttle) library for this, which provides throttling decorators for methods:
+
+```typescript
+import {controller} from '@github/catalyst'
+import {debounce} from '@github/mini-throttle/decorators'
+
+@controller
+class FuzzySearchElement extends HTMLElement {
+
+  // Adding `@debounce(100)` here means this method will only be called once in a 100ms period.
+  @debounce(100)
+  search(event: Event) {
+    const value = event.currentTarget.value
+    // This function is very computationally intensive, so we should run it as little as possible
+    this.filterAllItemsWithValue(value)
+  }
+
+}
+```
+
+Alternatively, if you'd like more precise control over the exact way debouncing happens (for example you'd like to make the debounce timeout dynamic, or sometimes call _without_ debouncing), you can have two methods following the pattern of `foo`/`fooNow` or `foo`/`fooSync`, where the non-suffixed method dispatches asynchronously to the `Now`/`Sync` suffixed method, a little like this:
+
+```typescript
+import {controller} from '@github/catalyst'
+
+@controller
+class FuzzySearchElement extends HTMLElement {
+
+  #searchAnimationFrame = 0
+  search(event: Event) {
+    clearAnimationFrame(this.#searchAnimationFrame)
+    this.#searchAnimationFrame = requestAnimationFrame(() => this.searchNow(event: Event))
+  }
+  
+  searchNow(event: Event) {
+    const value = event.currentTarget.value
+    // This function is very computationally intensive, so we should run it as little as possible
+    this.filterAllItemsWithValue(value)
+  }
+
+}
+```
+
+### Aborting Network Requests
+
+When making network requests using `fetch`, based on user input, you can cancel old requests as new ones come in. This is useful for performance as well as UI responsiveness, as old requests that aren't cancelled might complete later than newer ones, and causing the UI to jump around. Aborting network requests requires you to use [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) (a web platform feature).
+
+```typescript
+@controller
+class RemoveSearchElement extends HTMLElement {
+
+  #remoteSearchController: AbortController|null
+
+  async search(event: Event) {
+    // Abort the old Request
+    this.#remoteSearchController?.abort()
+
+    // To start making a new request, construct an AbortController
+    const {signal} = (this.#remoteSearchController = new AbortController())
+
+    try {
+      const res = await fetch(myUrl, {signal})
+
+      // ... Add logic here with the completed network response
+    } catch (e) {
+
+      // ... Add logic here if you need to report a failed network request.
+      // Do not rethrow for network errors!
+
+    }
+
+    if (signal.aborted) {
+      // Here you can add logic for if the request was cancelled, but
+      // usually what you want to do is just return early to avoid
+      // cleaning up the loading UI (bear in mind if the request is
+      // cancelled then another one will be in its place).
+      return
+    }
+
+    // ... Add cleanup logic here, such as removing `loading` classes.
+
+  }
+}
+```
+
+### Registering global or many event listeners
+
+Generally speaking, you'll want to use ["Actions"]({{ site.baseurl }}/guide/actions) to register event listeners with your Controller, but Actions only work for components nested within your Controller. It may also be necessary to listen for events on the Document, Window, or across well-known adjacent elements. We can manually call `addEventListener` for these types, including during the `connectedCallback` phase. Cleanup for `addEventListener` can be a bit error prone, but [`AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) can be useful here to pass a signal that the element is cleaning up. AbortControllers should be created once per `connectedCallback`, as they are not re-usable, while Controllers _can_ be reused.
+
+
+```typescript
+@controller
+class UnsavedChangesElement extends HTMLElement {
+
+  #eventAbortController: AbortController|null = null
+
+  connectedCallback(event: Event) {
+    // Create the new AbortController and get the new signal
+    const {signal} = (this.#eventAbortController = new AbortController())
+    
+    // You can `signal` as an option to any `addEventListener` call:
+    window.addEventListener('hashchange', this, { signal })
+    window.addEventListener('blur', this, { signal })
+    window.addEventListener('popstate', this, { signal })
+    window.addEventListener('pagehide', this, { signal })
+  }
+  
+  disconnectedCallback() {
+    // This will clean up any `addEventListener` calls which were given the `signal`
+    this.#eventAbortController?.abort()
+  }
+  
+  handleEvent(event) {
+    // `handleEvent` will be called when each one of the event listeners
+    // defined in `connectedCallback` is dispatched.
+  }
+}
+```

--- a/docs/_guide/patterns.md
+++ b/docs/_guide/patterns.md
@@ -1,6 +1,8 @@
 ---
-chapter: 11
-subtitle: Patterns
+version: 1
+chapter: 10
+title: Patterns
+subtitle: Best Practices for behaviours
 ---
 
 An aim of Catalyst is to be as light weight as possible, and so we often avoid including helper functions for otherwise fine code. We also want to keep Catalyst focussed, and so where some helper functions might be reasonable, we recommend judicious use of other small libraries.

--- a/docs/_guide/providable.md
+++ b/docs/_guide/providable.md
@@ -1,7 +1,9 @@
 ---
-chapter: 15
-subtitle: The Provider pattern
 version: 2
+chapter: 8
+title: Providable
+subtitle: The Provider pattern
+permalink: /guide-v2/providable
 ---
 
 The [Provider pattern](https://www.patterns.dev/posts/provider-pattern/) allows for deeply nested children to ask ancestors for values. This can be useful for decoupling state inside a component, centralising it higher up in the DOM heirarchy. A top level container component might store values, and many children can consume those values, without having logic duplicated across the app. It's quite an abstract pattern so is better explained with examples...

--- a/docs/_guide/providable.md
+++ b/docs/_guide/providable.md
@@ -1,7 +1,7 @@
 ---
 chapter: 15
 subtitle: The Provider pattern
-hidden: true
+version: 2
 ---
 
 The [Provider pattern](https://www.patterns.dev/posts/provider-pattern/) allows for deeply nested children to ask ancestors for values. This can be useful for decoupling state inside a component, centralising it higher up in the DOM heirarchy. A top level container component might store values, and many children can consume those values, without having logic duplicated across the app. It's quite an abstract pattern so is better explained with examples...

--- a/docs/_guide/rendering-2.md
+++ b/docs/_guide/rendering-2.md
@@ -1,0 +1,113 @@
+---
+version: 2
+chapter: 11
+title: Rendering
+subtitle: Rendering HTML subtrees
+permalink: /guide-v2/rendering
+---
+
+Sometimes it's necessary to render an HTML subtree as part of a component. This can be especially useful if a component is driving complex UI that is only interactive with JS.
+
+{% capture callout %}
+Remember to _always_ make your JavaScript progressively enhanced, where possible. Using JS to render large portions of the UI, that could be rendered server-side is an anti-pattern; it can be difficult for users to interact with - especially users who disable JS, or when JS fails to load, or those using assistive technologies. Rendering on the client can also impact the [CLS Web Vital](https://web.dev/cls/).
+{% endcapture %}{% include callout.md %}
+
+By leveraging the native [`ShadowDOM`](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM) feature, Catalyst components can render complex sub-trees, fully encapsulated from the rest of the page.
+
+Catalyst will automatically look for elements that match the `template[data-shadowroot]` selector, within your controller. If it finds one as a direct-child of your controller, it will use that to create a shadowRoot. 
+
+Catalyst Controllers will search for a direct child of `template[data-shadowroot]` and load its contents as the `shadowRoot` of the element. [Actions]({{ site.baseurl }}/guide/actions) and [Targets]({{ site.baseurl }}/guide/targets) all work within an elements ShadowRoot.
+
+### Example
+
+```html
+<hello-world>
+  <template data-shadowroot>
+    <p>
+      Hello <span data-target="hello-world.nameEl">World</span>
+    </p>
+  </template>
+</hello-world>
+```
+```typescript
+import { controller, target } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @target nameEl: HTMLElement
+  get name() {
+    return this.nameEl.textContent
+  }
+  set name(value: string) {
+    this.nameEl.textContent = value
+  }
+}
+```
+
+Providing the `<template data-shadowroot>` element as a direct child of the `hello-world` element tells Catalyst to render the templates contents automatically, and so all `HelloWorldElements` with this template will be rendered with the contents.
+
+{% capture callout %}
+Remember that _all_ instances of your controller _must_ add the `<template data-shadowroot>` HTML. If an instance does not have the `<template data-shadowroot>` as a direct child, then the shadow DOM won't be rendered for it!
+{% endcapture %}{% include callout.md %}
+
+### Updating a Template element using JS templates
+
+Sometimes you wont have a template that is server rendered, and instead want to make a template using JS. Catalyst does not support this out of the box, but it is possible to use another library: `@github/jtml`. This library can be used to write declarative templates using JS. Let's re-work the above example using `@github/jtml`:
+
+```typescript
+import { attr, controller } from "@github/catalyst"
+import { html, render } from "@github/jtml"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @attr name = 'World'
+
+  connectedCallback() {
+    this.attachShadow({mode: 'open'})
+  }
+
+  attributeChangedCallback() {
+    render(() => html`
+      <div>
+        Hello <span>${ this.name }</span>
+      </div>`,
+    this.shadowRoot!)
+  }
+}
+```
+
+Here, instead of declaring our template in HTML, we can do so in JS, and achieve exactly the same effect. We aren't using `@targets` in this example, as there is a more direct way to handle the data; relying on `attributeChangedCallback` which will efficiently update only the parts that change.
+
+The same effect could be achieved without using `@attr` via:
+
+```typescript
+import { controller } from "@github/catalyst"
+import { html, render } from "@github/jtml"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+
+  // Make `name` automatically update when changed
+  #name = 'World'
+  get name() {
+    return this.#name
+  }
+  set name(value: string) {
+    this.#name = value
+    this.update()
+  }
+
+  connectedCallback() {
+    this.attachShadow({mode: 'open'})
+    this.update()
+  }
+
+  update() {
+    render(() => html`
+      <div>
+        Hello <span>${ this.#name }</span>
+      </div>`,
+    this.shadowRoot!)
+  }
+}
+```

--- a/docs/_guide/rendering.md
+++ b/docs/_guide/rendering.md
@@ -1,5 +1,7 @@
 ---
+version: 1
 chapter: 8
+title: Rendering
 subtitle: Rendering HTML subtrees
 ---
 

--- a/docs/_guide/targets-2.md
+++ b/docs/_guide/targets-2.md
@@ -1,0 +1,159 @@
+---
+version: 2
+chapter: 5
+title: Targetable
+subtitle: Querying Descendants
+permalink: /guide-v2/targets
+---
+
+One of the three [core patterns]({{ site.baseurl }}/guide/introduction#three-core-concepts-observe-listen-query) is Querying. In Catalyst, Targets are the preferred way to query. Targets use `querySelector` under the hood, but in a way that makes it a lot simpler to work with.
+
+Catalyst Components are really just Web Components, so you could use `querySelector` or `querySelectorAll` to select descendants of the element. Targets avoid some of the problems of `querySelector`; they provide a more consistent interface, avoid coupling CSS classes or HTML tag names to JS, and they handle subtle issues like nested components. Targets are also a little more ergonomic to reuse in a class. We'd recommend using Targets over `querySelector` wherever you can.
+
+To create a Target, use the `@target` decorator on a class field, and add the matching `data-target` attribute to your HTML, like so:
+
+### Example
+
+<div class="d-flex my-4">
+  <div>
+<!-- annotations
+data-target ".*": This maps to the `@target output` property
+-->
+
+```html
+<hello-world>
+  <span
+    data-target="hello-world.output">
+  </span>
+</hello-world>
+```
+
+  </div>
+  <div class="ml-4">
+
+<!-- annotations
+@ target output: This maps to the data-target attribute
+-->
+
+```js
+import { controller, target } from "@github/catalyst"
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  @target output: HTMLElement
+
+  greet() {
+    this.output.textContent = `Hello, world!`
+  }
+}
+```
+
+  </div>
+</div>
+
+### Target Syntax
+
+The target syntax follows a pattern of `controller.target`.
+
+ - `controller` must be the name of a controller ascendant to the element.
+ - `target` must be the name matching that of a `@target` (or `@targets`) annotated field within the Controller code.
+
+### Multiple Targets
+
+{% capture callout %} 
+Remember! There are two decorators available, `@target` which fetches only one `data-target` element, and `@targets` which fetches multiple `data-targets` elements!
+{% endcapture %}{% include callout.md %}
+
+The `@target` decorator will only ever return _one_ element, just like `querySelector`. If you want to get multiple Targets, you need the `@targets` decorator which works almost the same, but returns an Array of elements, and it searches the `data-targets` attribute (not `data-target`). 
+
+Elements can be referenced as multiple targets, and targets may be referenced multiple times within the HTML:
+
+<!-- annotations
+data-targets ".*users": This maps to the `@targets users` property
+data-target ".*read": This maps to the `@target read` property
+data-target ".*write": This maps to the `@target write` property
+-->
+
+```html
+<team-members>
+  <user-list>
+    <user-settings data-targets="user-list.users">
+      <input type="checkbox" data-target="user-settings.read">
+      <input type="checkbox" data-target="user-settings.write">
+    </user-settings>
+    <user-settings data-targets="user-list.users">
+      <input type="checkbox" data-target="user-settings.read">
+      <input type="checkbox" data-target="user-settings.write">
+    </user-settings>
+  </user-list>
+</team-members>
+```
+
+<br>
+
+<!-- annotations
+@ targets users: This maps to the data-targets attribute
+@ target read: This maps to the data-target attribute
+@ target write: This maps to the data-target attribute
+-->
+
+```js
+import { controller, target, targets } from "@github/catalyst"
+
+@controller
+class UserSettingsElement extends HTMLElement {
+  @target read: HTMLInputElement
+  @target write: HTMLInputElement
+
+  valid() {
+    // At least one checkbox must be checked!
+    return this.read.checked || this.write.checked
+  }
+}
+
+@controller
+class UserListElement extends HTMLElement {
+  @targets users: HTMLElement[]
+
+  valid() {
+    // Every user must be valid!
+    return this.users.every(user => user.valid())
+  }
+}
+```
+
+### Target Vs Targets
+
+To clarify the difference between `@target` and `@targets` here is a handy table:
+
+| Decorator  | Equivalent Native Method | Selector           | Returns          | 
+|:-----------|:-------------------------|:-------------------|:-----------------|
+| `@target`  | `querySelector`          | `data-target="*"`  | `Element`        | 
+| `@targets` | `querySelectorAll`       | `data-targets="*"` | `Array<Element>` | 
+
+### Targets and "ShadowRoots"
+
+Custom elements can create encapsulated DOM trees known as "Shadow" DOM. Catalyst targets support Shadow DOM by traversing the `shadowRoot` first, if present.
+
+Important to note here is that nodes from the `shadowRoot` get returned _first_. So `@targets` will return an array of nodes, where shadowRoot nodes are at the start of the Array, and `@target` will return a ShadowRoot target if it exists, otherwise it will fall back to traversing the elements direct children.
+
+### What about without Decorators?
+
+If you're using decorators, then the `@target` and `@targets` decorators will turn the decorated properties into getters.
+
+If you're not using decorators, then you'll need to make a `getter`, and call `findTarget(this, key)` or `findTargets(this, key)` in the getter, for example:
+
+```js
+import {findTarget, findTargets} from '@github/catalyst'
+class HelloWorldElement extends HTMLElement {
+
+  get output() {
+    return findTarget(this, 'output')
+  }
+
+  get pages() {
+    return findTargets(this, 'pages')
+  }
+
+}
+```

--- a/docs/_guide/targets.md
+++ b/docs/_guide/targets.md
@@ -1,5 +1,7 @@
 ---
-chapter: 5
+version: 1
+chapter: 4
+title: Targets
 subtitle: Querying Descendants
 ---
 

--- a/docs/_guide/testing-2.md
+++ b/docs/_guide/testing-2.md
@@ -1,6 +1,6 @@
 ---
-version: 1
-chapter: 14
+version: 2
+chapter: 13
 title: Testing
 subtitle: Tips for automated testing
 ---

--- a/docs/_guide/testing.md
+++ b/docs/_guide/testing.md
@@ -1,6 +1,8 @@
 ---
-chapter: 13
-subtitle: Testing
+version: 1
+chapter: 12
+title: Testing
+subtitle: Tips for automated testing
 ---
 
 Catalyst controllers are based on Web Components, and as such need the Web Platform environment to run in, including in tests. It's possible to run these tests in "browser like" environments such as NodeJS or Deno with libraries like jsdom, but it's best to run tests directly in the browser.

--- a/docs/_guide/your-first-component-2.md
+++ b/docs/_guide/your-first-component-2.md
@@ -1,0 +1,83 @@
+---
+version: 2
+chapter: 2
+title: Your First Component
+subtitle: Building an HTMLElement
+permalink: /guide-v2/your-first-component
+---
+
+### Catalyst's `@controller` decorator
+
+Catalyst's `@controller` decorator lets you create Custom Elements with virtually no boilerplate, by automatically calling `customElements.register`, and by adding ["Actions"]({{ site.baseurl }}/guide/actions) and ["Targets"]({{ site.baseurl }}/guide/targets) features described later. Using TypeScript (with `decorators` support enabled), simply add `@controller` to the top of your class:
+
+<!-- annotations
+controller: This must be added to all Catalyst controllers.
+extends HTMLElement: This must be added to all Catalyst controllers.
+connectedCallback: This runs when the element is added to the DOM | {{ site.baseurl }}/guide/lifecycle-hooks/#codeconnectedcallbackcode
+-->
+
+```js
+import {controller} from '@github/catalyst'
+
+@controller
+class HelloWorldElement extends HTMLElement {
+  connectedCallback() {
+    this.innerHTML = 'Hello World!'
+  }
+}
+```
+<br>
+
+Catalyst will automatically convert the classes name; removing the trailing `Element` suffix and lowercasing all capital letters, separating them with a dash.
+
+By convention Catalyst controllers end in `Element`; Catalyst will omit this when generating a tag name. The `Element` suffix is _not_ required - just convention. All examples in this guide use `Element` suffixed names.
+
+{% capture callout %}
+Remember! A class name _must_ include at least two CamelCased words (not including the `Element` suffix). One-word elements will raise exceptions. Example of good names: `UserListElement`, `SubTaskElement`, `PagerContainerElement`
+{% endcapture %}{% include callout.md %}
+
+
+### What does `@controller` do?
+
+The `@controller` decorator ties together the various other decorators within Catalyst, plus a few extra conveniences such as automatically registering the element, which saves you writing some boilerplate that you'd otherwise have to write by hand. Specifically the `@controller` decorator:
+
+ - Derives a tag name based on your class name, removing the trailing `Element` suffix and lowercasing all capital letters, separating them with a dash.
+ - Calls `window.customElements.define` with the newly derived tag name and your class.
+ - Calls `defineObservedAttributes` with the class to add map any `@attr` decorators. See [attrs]({{ site.baseurl }}/guide/attrs) for more on this.
+ - Injects the following code inside of the `connectedCallback()` function of your class:
+   - `bind(this)`; ensures that as your element connects it picks up any `data-action` handlers. See [actions]({{ site.baseurl }}/guide/actions) for more on this.
+   - `autoShadowRoot(this)`; ensures that your element loads any `data-shadowroot` templates. See [rendering]({{ site.baseurl }}/guide/rendering) for more on this.
+   - `initializeAttrs(this)`; ensures that your element binds any `data-*` attributes to props. See [attrs]({{ site.baseurl }}/guide/attrs) for more on this.
+ 
+You can do all of this manually; for example here's the above `HelloWorldElement`, written without the `@controller` annotation:
+
+```js
+import {bind, autoShadowRoot, initializeAttrs, defineObservedAttributes} from '@github/catalyst'
+class HelloWorldElement extends HTMLElement {
+  connectedCallback() {
+    autoShadowRoot(this)
+    initializeAttrs(this)
+    this.innerHTML = 'Hello World!'
+    bind(this)
+  }
+}
+defineObservedAttributes(HelloWorldElement)
+window.customElements.define('hello-world', HelloWorldElement)
+```
+
+The `@controller` decorator saves on having to write this boilerplate for each element.
+
+### What about without TypeScript Decorators?
+
+If you don't want to use TypeScript decorators, you can use `controller` as a regular function by passing it to your class:
+
+```js
+import {controller} from '@github/catalyst'
+
+controller(
+  class HelloWorldElement extends HTMLElement {
+    //...
+  }
+)
+```
+<br>

--- a/docs/_guide/your-first-component.md
+++ b/docs/_guide/your-first-component.md
@@ -1,6 +1,8 @@
 ---
+version: 1
+chapter: 2
+title: Your First Component
 subtitle: Building an HTMLElement
-chapter: 3
 ---
 
 ### Catalyst's `@controller` decorator

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -1,4 +1,13 @@
 <aside class="col-lg-3 pl-4 pt-1 pb-1 bg-gray">
+  <label class="d-flex mr-4 flex-items-center">
+    <span class="mr-4">Version</span> 
+    <select class="flex-1" onchange="window.location.href = this.value">
+      <option value="/guide/introduction" {% if page.version == 1 %} selected{% endif %}>v1.x.x</option>
+      <option value="/guide-v2/introduction" {% if page.version == 2 %} selected{% endif %}>v2.x.x</option>
+    </select>
+  </label>
+  <br>
+
   <nav class="position-sticky top-100px">
     <ol class="f3-light ml-4">
       {% for item in sidebarItems %}

--- a/docs/_layouts/guide.html
+++ b/docs/_layouts/guide.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% assign sidebarItems = site.guide | where_exp: "item", "item.hidden != true" | sort: 'chapter' %}
+{% assign sidebarItems = site.guide | where_exp: "item", "item.version == page.version" | sort: 'chapter' %}
 
 {% for item in sidebarItems  %}
   {% if item.title == page.title %}

--- a/docs/_layouts/guide.html
+++ b/docs/_layouts/guide.html
@@ -22,6 +22,13 @@ layout: default
 
   <section class="col-lg-9 px-5 f4">
     <div class="container-md markdown-body mb-5">
+      {% if page.version == 2 %}
+      <div class="flash flash-warn">
+        You are reading the documentation for the <strong>Alpha</strong> version of Catalyst. The API and documentation is subject to change.
+        The documentation for the stable version can <a href="{{ site.baseurl }}/guide/introduction">be found here</a>.
+      </div>
+      {% endif %}
+
       <h1 class="mb-4 f0-light">{{ page.title }}</h1>
       {{ content }}
       <div class="mt-4">


### PR DESCRIPTION
It's getting a little difficult to manage the v2 branch documentation, and as we migrate to v2 and more projects use it, it is becoming more useful to consult the v2 docs on the live site.

As such, this adds a v2 version of the documentation, which gives us the opportunity to view the two docs on the site.