### PR TITLE
Add failing test for default-valued properties

### DIFF
--- a/test/attrable.ts
+++ b/test/attrable.ts
@@ -19,6 +19,16 @@ describe('Attrable', () => {
         this.setCount += 1
         this.#bing = value
       }
+      lastSetHasFoo: any
+      @attr get hasFoo() {
+        return false
+      }
+      set hasFoo(v: boolean) {
+        this.lastSetHasFoo = v
+      }
+      connectedCallback() {
+        this.hasFoo = true
+      }
     }
     window.customElements.define('initialize-attr-test', InitializeAttrTest)
 
@@ -103,6 +113,10 @@ describe('Attrable', () => {
       expect(instance).to.have.property('fooBar', 'goodbye')
       instance.bingBaz = 'universe'
       expect(instance).to.have.property('bingBaz', 'universe')
+    })
+    
+    it('updates default-valued properties in the connected callback', async () => {
+      expect(instance).to.have.property('lastSetHasFoo', true)
     })
   }
 


### PR DESCRIPTION
@attr properties with a default value (specified using a getter method) incorrectly have their setter method called with an empty string after setting the property in the connectedCallback

This incorrect behaviour does not happen if:

- the property is in the html definition eg `<initialize-attr-test has-foo='' />`
- the property does not have a getter method supplying a default value