### PR TITLE
Observe shadow root on connected callback

### DIFF
--- a/docs/_guide/rendering-2.md
+++ b/docs/_guide/rendering-2.md
@@ -89,7 +89,7 @@ class HelloWorldElement extends HTMLElement {
   }
 
   attributeChangedCallback() {
-    render(() => html`
+    render(html`
       <div>
         Hello <span>${ this.name }</span>
       </div>`,
@@ -125,7 +125,7 @@ class HelloWorldElement extends HTMLElement {
   }
 
   update() {
-    render(() => html`
+    render(html`
       <div>
         Hello <span>${ this.#name }</span>
       </div>`,

--- a/docs/_guide/rendering.md
+++ b/docs/_guide/rendering.md
@@ -66,7 +66,7 @@ class HelloWorldElement extends HTMLElement {
   }
 
   attributeChangedCallback() {
-    render(() => html`
+    render(html`
       <div>
         Hello <span>${ this.name }</span>
       </div>`,
@@ -102,7 +102,7 @@ class HelloWorldElement extends HTMLElement {
   }
 
   update() {
-    render(() => html`
+    render(html`
       <div>
         Hello <span>${ this.#name }</span>
       </div>`,

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,6 +3,7 @@ import {bind, bindShadow} from './bind.js'
 import {autoShadowRoot} from './auto-shadow-root.js'
 import {defineObservedAttributes, initializeAttrs} from './attr.js'
 import type {CustomElementClass} from './custom-element.js'
+import {observe} from './lazy-define.js'
 
 const symbol = Symbol.for('catalyst')
 
@@ -57,7 +58,10 @@ export class CatalystDelegate {
     initializeAttrs(instance)
     bind(instance)
     connectedCallback?.call(instance)
-    if (instance.shadowRoot) bindShadow(instance.shadowRoot)
+    if (instance.shadowRoot) {
+      bindShadow(instance.shadowRoot)
+      observe(instance.shadowRoot)
+    }
   }
 
   disconnectedCallback(element: HTMLElement, disconnectedCallback: () => void) {

--- a/test/controller.ts
+++ b/test/controller.ts
@@ -1,7 +1,8 @@
 import {expect, fixture, html} from '@open-wc/testing'
-import {replace, fake} from 'sinon'
+import {replace, fake, spy} from 'sinon'
 import {controller} from '../src/controller.js'
 import {attr} from '../src/attr.js'
+import {lazyDefine} from '../src/lazy-define.js'
 
 describe('controller', () => {
   let instance
@@ -63,6 +64,23 @@ describe('controller', () => {
     instance.shadowRoot!.querySelector('button')!.click()
 
     expect(instance.foo).to.have.callCount(1)
+  })
+
+  it('observes changes on shadowRoots', async () => {
+    const onDefine = spy()
+    lazyDefine('nested-shadow-element', onDefine)
+
+    @controller
+    class ControllerObserveShadowElement extends HTMLElement {
+      connectedCallback() {
+        const shadowRoot = this.attachShadow({mode: 'open'})
+        // eslint-disable-next-line github/unescaped-html-literal
+        shadowRoot.innerHTML = '<div><nested-shadow-element></nested-shadow-element></div>'
+      }
+    }
+    instance = await fixture<ControllerObserveShadowElement>(html`<controller-observe-shadow />`)
+
+    expect(onDefine).to.be.callCount(1)
   })
 
   it('binds auto shadowRoots', async () => {

--- a/test/lazy-define.ts
+++ b/test/lazy-define.ts
@@ -1,6 +1,6 @@
 import {expect, fixture, html} from '@open-wc/testing'
 import {spy} from 'sinon'
-import {lazyDefine} from '../src/lazy-define.js'
+import {lazyDefine, observe} from '../src/lazy-define.js'
 
 const animationFrame = () => new Promise<unknown>(resolve => requestAnimationFrame(resolve))
 
@@ -44,6 +44,21 @@ describe('lazyDefine', () => {
       await animationFrame()
 
       expect(onDefine).to.be.callCount(2)
+    })
+
+    it('lazy loads elements in shadow roots', async () => {
+      const onDefine = spy()
+      lazyDefine('nested-shadow-element', onDefine)
+
+      const el = await fixture(html` <div></div> `)
+      const shadowRoot = el.attachShadow({mode: 'open'})
+      observe(shadowRoot)
+      // eslint-disable-next-line github/unescaped-html-literal
+      shadowRoot.innerHTML = '<div><nested-shadow-element></nested-shadow-element></div>'
+
+      await animationFrame()
+
+      expect(onDefine).to.be.callCount(1)
     })
   })
 


### PR DESCRIPTION
## Description

While poking around and learning about catalyst I tried to use [dynamic rendering](https://catalyst.rocks/guide/rendering/) on the shadow DOM for both a `parent` and a `child` custom web component. I was able to see the parent attach the child but the contents of the child were not attached to the DOM.

### Why tho?

The existing `lazyDefine` creates a `MutationObserver` that listens to the entire `document`, but shadow roots live as a separate isolated node and so when the shadow root of the `parent` contained `child`, the import callback held in `dynamicElements` was not being called.

### What's the fix?

We exported a new `observe` function which will observe for changes on the provided `ElementLike`. Then in the controller `connectedCallback`, if there is a `shadowRoot`, we'll observe it.

CC @keithamus who I paired on this with