### PR TITLE
Docs: surface required delimiters for Targets' and Actions' syntax patterns

### DIFF
--- a/docs/_guide/actions.md
+++ b/docs/_guide/actions.md
@@ -68,7 +68,9 @@ class HelloWorldElement extends HTMLElement {
 The actions syntax follows a pattern of `event:controller#method`.
 
  - `event` must be the name of a [_DOM Event_](https://developer.mozilla.org/en-US/docs/Web/Events), e.g. `click`.
+ - `:` is the required delimiter between the `event` and `controller`.
  - `controller` must be the name of a controller ascendant to the element.
+ - `#` is the required delimieter between the `controller` and `method`.
  - `method` (optional) must be a _public_ _method_ attached to a controller's prototype. Static methods will not work.
 
 If method is not supplied, it will default to `handleEvent`.

--- a/docs/_guide/targets.md
+++ b/docs/_guide/targets.md
@@ -55,6 +55,7 @@ class HelloWorldElement extends HTMLElement {
 The target syntax follows a pattern of `controller.target`.
 
  - `controller` must be the name of a controller ascendant to the element.
+ - `.` is the required delimiter between `controller` and `target`.
  - `target` must be the name matching that of a `@target` (or `@targets`) annotated field within the Controller code.
 
 ### Multiple Targets


### PR DESCRIPTION
## Summary

Closes #319

This PR notates the required delimiters for the syntax patterns of Targets and Actions in the documentation. The changes are beneficial because they provide clarity and consistency in the documentation, making it easier for users to understand and follow the syntax patterns for Targets and Actions (specifically, that they don't use random characters as delimiters! 😉 ).

