### PR TITLE
fix: coalesce scan() into a single rAF to avoid paint delay on bulk DOM mutations

### DIFF
--- a/src/lazy-define.ts
+++ b/src/lazy-define.ts
@@ -57,26 +57,33 @@ const strategies: Record<string, Strategy> = {
 
 type ElementLike = Element | Document | ShadowRoot
 
-const timers = new WeakMap<ElementLike, number>()
+const pendingElements = new Set<ElementLike>()
+let scanTimer: number | null = null
+
 function scan(element: ElementLike) {
-  cancelAnimationFrame(timers.get(element) || 0)
-  timers.set(
-    element,
-    requestAnimationFrame(() => {
+  pendingElements.add(element)
+  if (scanTimer != null) return
+  scanTimer = requestAnimationFrame(() => {
+    scanTimer = null
+    if (!dynamicElements.size) {
+      pendingElements.clear()
+      return
+    }
+    for (const el of pendingElements) {
       for (const tagName of dynamicElements.keys()) {
         const child: Element | null =
-          element instanceof Element && element.matches(tagName) ? element : element.querySelector(tagName)
+          el instanceof Element && el.matches(tagName) ? el : el.querySelector(tagName)
         if (customElements.get(tagName) || child) {
           const strategyName = (child?.getAttribute('data-load-on') || 'ready') as keyof typeof strategies
           const strategy = strategyName in strategies ? strategies[strategyName] : strategies.ready
           // eslint-disable-next-line github/no-then
           for (const cb of dynamicElements.get(tagName) || []) strategy(tagName).then(cb)
           dynamicElements.delete(tagName)
-          timers.delete(element)
         }
       }
-    })
-  )
+    }
+    pendingElements.clear()
+  })
 }
 
 let elementLoader: MutationObserver

--- a/src/lazy-define.ts
+++ b/src/lazy-define.ts
@@ -6,14 +6,14 @@ const ready = new Promise<void>(resolve => {
   if (document.readyState !== 'loading') {
     resolve()
   } else {
-    document.addEventListener('readystatechange', () => resolve(), {once: true})
+    document.addEventListener('readystatechange', () => resolve(), { once: true })
   }
 })
 
 const firstInteraction = new Promise<void>(resolve => {
   const controller = new AbortController()
   controller.signal.addEventListener('abort', () => resolve())
-  const listenerOptions = {once: true, passive: true, signal: controller.signal}
+  const listenerOptions = { once: true, passive: true, signal: controller.signal }
   const handler = () => controller.abort()
 
   document.addEventListener('mousedown', handler, listenerOptions)
@@ -65,11 +65,12 @@ function scan(element: ElementLike) {
   if (scanTimer != null) return
   scanTimer = requestAnimationFrame(() => {
     scanTimer = null
+    const elements = new Set(pendingElements)
+    pendingElements.clear()
     if (!dynamicElements.size) {
-      pendingElements.clear()
       return
     }
-    for (const el of pendingElements) {
+    outer: for (const el of elements) {
       for (const tagName of dynamicElements.keys()) {
         const child: Element | null = el instanceof Element && el.matches(tagName) ? el : el.querySelector(tagName)
         if (customElements.get(tagName) || child) {
@@ -78,10 +79,10 @@ function scan(element: ElementLike) {
           // eslint-disable-next-line github/no-then
           for (const cb of dynamicElements.get(tagName) || []) strategy(tagName).then(cb)
           dynamicElements.delete(tagName)
+          if (!dynamicElements.size) break outer
         }
       }
     }
-    pendingElements.clear()
   })
 }
 
@@ -91,7 +92,7 @@ export function lazyDefine(object: Record<string, () => void>): void
 export function lazyDefine(tagName: string, callback: () => void): void
 export function lazyDefine(tagNameOrObj: string | Record<string, () => void>, singleCallback?: () => void) {
   if (typeof tagNameOrObj === 'string' && singleCallback) {
-    tagNameOrObj = {[tagNameOrObj]: singleCallback}
+    tagNameOrObj = { [tagNameOrObj]: singleCallback }
   }
   for (const [tagName, callback] of Object.entries(tagNameOrObj)) {
     if (!dynamicElements.has(tagName)) dynamicElements.set(tagName, new Set<() => void>())
@@ -112,5 +113,5 @@ export function observe(target: ElementLike): void {
 
   scan(target)
 
-  elementLoader.observe(target, {subtree: true, childList: true})
+  elementLoader.observe(target, { subtree: true, childList: true })
 }

--- a/src/lazy-define.ts
+++ b/src/lazy-define.ts
@@ -6,14 +6,14 @@ const ready = new Promise<void>(resolve => {
   if (document.readyState !== 'loading') {
     resolve()
   } else {
-    document.addEventListener('readystatechange', () => resolve(), { once: true })
+    document.addEventListener('readystatechange', () => resolve(), {once: true})
   }
 })
 
 const firstInteraction = new Promise<void>(resolve => {
   const controller = new AbortController()
   controller.signal.addEventListener('abort', () => resolve())
-  const listenerOptions = { once: true, passive: true, signal: controller.signal }
+  const listenerOptions = {once: true, passive: true, signal: controller.signal}
   const handler = () => controller.abort()
 
   document.addEventListener('mousedown', handler, listenerOptions)
@@ -92,7 +92,7 @@ export function lazyDefine(object: Record<string, () => void>): void
 export function lazyDefine(tagName: string, callback: () => void): void
 export function lazyDefine(tagNameOrObj: string | Record<string, () => void>, singleCallback?: () => void) {
   if (typeof tagNameOrObj === 'string' && singleCallback) {
-    tagNameOrObj = { [tagNameOrObj]: singleCallback }
+    tagNameOrObj = {[tagNameOrObj]: singleCallback}
   }
   for (const [tagName, callback] of Object.entries(tagNameOrObj)) {
     if (!dynamicElements.has(tagName)) dynamicElements.set(tagName, new Set<() => void>())
@@ -113,5 +113,5 @@ export function observe(target: ElementLike): void {
 
   scan(target)
 
-  elementLoader.observe(target, { subtree: true, childList: true })
+  elementLoader.observe(target, {subtree: true, childList: true})
 }

--- a/src/lazy-define.ts
+++ b/src/lazy-define.ts
@@ -71,8 +71,7 @@ function scan(element: ElementLike) {
     }
     for (const el of pendingElements) {
       for (const tagName of dynamicElements.keys()) {
-        const child: Element | null =
-          el instanceof Element && el.matches(tagName) ? el : el.querySelector(tagName)
+        const child: Element | null = el instanceof Element && el.matches(tagName) ? el : el.querySelector(tagName)
         if (customElements.get(tagName) || child) {
           const strategyName = (child?.getAttribute('data-load-on') || 'ready') as keyof typeof strategies
           const strategy = strategyName in strategies ? strategies[strategyName] : strategies.ready

--- a/test/lazy-define.ts
+++ b/test/lazy-define.ts
@@ -68,6 +68,38 @@ describe('lazyDefine', () => {
       expect(onDefine3).to.have.callCount(1)
     })
 
+    it('coalesces multiple added elements into a single rAF callback', async () => {
+      const onDefine = spy()
+      lazyDefine('coalesce-test-element', onDefine)
+
+      const rafSpy = spy(window, 'requestAnimationFrame')
+      const callsBefore = rafSpy.callCount
+
+      await fixture(html`
+        <div>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+          <coalesce-test-element></coalesce-test-element>
+        </div>
+      `)
+
+      await animationFrame()
+
+      const rafCallsFromScan = rafSpy.callCount - callsBefore
+      rafSpy.restore()
+
+      // Should use at most a few rAF calls, not one per element
+      expect(rafCallsFromScan).to.be.lessThan(5)
+      expect(onDefine).to.be.callCount(1)
+    })
+
     it('lazy loads elements in shadow roots', async () => {
       const onDefine = spy()
       lazyDefine('nested-shadow-element', onDefine)


### PR DESCRIPTION
## Summary

Fixes #343

When many elements are added to the DOM in a single frame (e.g. a framework rendering a list), the `scan()` function in `lazy-define.ts` was scheduling a separate `requestAnimationFrame` callback for **each element**. Since all rAF callbacks run before the browser paints, this delayed the first paint proportionally to the number of added elements.

## Changes

Replaced the per-element `WeakMap` + `requestAnimationFrame` deduplication with:
- A shared `Set<ElementLike>` that collects pending elements
- A single `requestAnimationFrame` timer that processes all pending elements in one callback

This ensures that no matter how many elements are added in a single frame, only **one** rAF callback runs before paint.

## Testing

Added a test that verifies multiple elements added at once are coalesced into minimal rAF calls rather than one per element. All existing tests continue to pass.